### PR TITLE
Prevent a crash when clicking the "i" button

### DIFF
--- a/src/urh/controller/SignalDetailsController.py
+++ b/src/urh/controller/SignalDetailsController.py
@@ -3,16 +3,18 @@ import os
 import time
 
 from PyQt5.QtCore import Qt, pyqtSlot
-from PyQt5.QtWidgets import QDialog
+from PyQt5.QtWidgets import QDialog, QMessageBox
 
 from urh.ui.ui_signal_details import Ui_SignalDetails
 from urh.util.Formatter import Formatter
-
+from urh.util import FileOperator
 
 class SignalDetailsController(QDialog):
     def __init__(self, signal, parent=None):
         super().__init__(parent)
         self.signal = signal
+        if not os.path.isfile(self.signal.filename):
+            self.save_signal_as()
         self.ui = Ui_SignalDetails()
         self.ui.setupUi(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
@@ -36,3 +38,13 @@ class SignalDetailsController(QDialog):
     def set_duration(self):
         dur = self.signal.num_samples / self.signal.sample_rate
         self.ui.lDuration.setText(Formatter.science_time(dur))
+
+    def save_signal_as(self):
+        filename = FileOperator.get_save_file_name(self.signal.filename, wav_only=self.signal.wav_mode)
+        if filename:
+            try:
+                self.signal.save_as(filename)
+            except Exception as e:
+                QMessageBox.critical(self, self.tr("Error saving signal"), e.args[0])
+
+                                                            


### PR DESCRIPTION
 Before the sub-sample has been saved to a file. We pop-up a file save dialog now. 
See https://github.com/jopohl/urh/issues/196

Once the signal has been saved to a file then the "Signal Details" window will appear.

There exists one problem with the FileDialog here. If the "Cancel" button is selected we get the same crash that we are fixing with this commit. I can create another issue for that if this gets pulled.
