### PR TITLE
send bits argument to subprocess properly

### DIFF
--- a/src/urh/signalprocessing/Encoding.py
+++ b/src/urh/signalprocessing/Encoding.py
@@ -393,7 +393,7 @@ class Encoding(object):
         # print(command, param)
         try:
             import subprocess
-            p = subprocess.Popen([command + " " + param],
+            p = subprocess.Popen([command, param],
                                  shell=True,
                                  # stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE)


### PR DESCRIPTION
using concatenation to spawn the subprocess broke the ability to easily use scripts to decode on windows as demonstrated by the following debug output:

```
'"C:/Users/x/Desktop/decode.rb 10010110"' is not recognized as an internal or external command,
operable program or batch file.
```

this change fixes the ability to use ruby scripts on windows when the file is associated properly, but i didn't test other platforms.