### PR TITLE
Bugfix for participant assignment when loading project with hidden messages

### DIFF
--- a/src/urh/controller/CompareFrameController.py
+++ b/src/urh/controller/CompareFrameController.py
@@ -196,11 +196,23 @@ class CompareFrameController(QWidget):
     @property
     def protocol_list(self):
         """
+        :return: visible protocols
         :rtype: list of ProtocolAnalyzer
         """
         result = []
         for group in self.groups:
             result.extend(group.protocols)
+        return result
+
+    @property
+    def full_protocol_list(self):
+        """
+        :return: all protocols including not shown ones
+        :rtype: list of ProtocolAnalyzer
+        """
+        result = []
+        for group in self.groups:
+            result.extend(group.all_protocols)
         return result
 
     # endregion
@@ -559,8 +571,10 @@ class CompareFrameController(QWidget):
                 if line != 0:
                     first_msg_indices.append(line)
 
-        # Hidden Rows auf neue Reihenfolge übertragen
-        [self.ui.tblViewProtocol.showRow(i) for i in range(self.protocol_model.row_count)]
+        # apply hidden rows to new order
+        for i in range(self.protocol_model.row_count):
+            self.ui.tblViewProtocol.showRow(i)
+
         self.protocol_model.hidden_rows.clear()
         for proto in relative_hidden_row_positions.keys():
             try:

--- a/src/urh/signalprocessing/ProtocolAnalyzer.py
+++ b/src/urh/signalprocessing/ProtocolAnalyzer.py
@@ -544,8 +544,20 @@ class ProtocolAnalyzer(object):
                 break
 
     def to_xml_tag(self, decodings, participants, tag_name="protocol", include_message_type=False,
-                   write_bits=False) -> ET.Element:
+                   write_bits=False, messages=None) -> ET.Element:
+        """
+
+        :param decodings:
+        :param participants:
+        :param tag_name:
+        :param include_message_type:
+        :param write_bits:
+        :param messages: Give custom list of messages to use instead of self.messages. Used when saving project and
+        some subprotocols are hidden in Compare Frame Controller
+        :return:
+        """
         root = ET.Element(tag_name)
+        messages = self.messages if messages is None else messages
 
         # Save modulators
         if hasattr(self, "modulators"):  # For protocol analyzer container
@@ -556,7 +568,7 @@ class ProtocolAnalyzer(object):
         # Save decodings
         if not decodings:
             decodings = []
-            for message in self.messages:
+            for message in messages:
                 if message.decoder not in decodings:
                     decodings.append(message.decoder)
 
@@ -571,7 +583,7 @@ class ProtocolAnalyzer(object):
         # Save participants
         if not participants:
             participants = []
-            for message in self.messages:
+            for message in messages:
                 if message.participant and message.participant not in participants:
                     participants.append(message.participant)
 
@@ -581,7 +593,7 @@ class ProtocolAnalyzer(object):
 
         # Save data
         data_tag = ET.SubElement(root, "messages")
-        for i, message in enumerate(self.messages):
+        for i, message in enumerate(messages):
             message_tag = message.to_xml(decoders=decodings, include_message_type=include_message_type)
             if write_bits:
                 message_tag.set("bits", message.plain_bits_str)

--- a/src/urh/util/ProjectManager.py
+++ b/src/urh/util/ProjectManager.py
@@ -170,7 +170,7 @@ class ProjectManager(QObject):
         if os.path.relpath(signal.filename, self.project_path) in existing_filenames.keys():
             signal_tag = existing_filenames[os.path.relpath(signal.filename, self.project_path)]
         else:
-            # Neuen Tag anlegen
+            # Create new tag
             signal_tag = ET.SubElement(root, "signal")
 
         signal_tag.set("name", signal.name)
@@ -351,9 +351,9 @@ class ProjectManager(QObject):
             root = tree.getroot()
             file_names = []
 
-            for ftag in root.findall("open_file"):
-                pos = int(ftag.attrib["position"])
-                filename = os.path.join(self.project_path, ftag.attrib["name"])
+            for file_tag in root.findall("open_file"):
+                pos = int(file_tag.attrib["position"])
+                filename = os.path.realpath(os.path.join(self.project_path, file_tag.attrib["name"]))
                 file_names.insert(pos, filename)
 
             QApplication.setOverrideCursor(Qt.WaitCursor)
@@ -380,7 +380,7 @@ class ProjectManager(QObject):
             group = tree_root.child(int(id))
 
             for proto_tag in group_tag.iter("cf_protocol"):
-                filename = os.path.join(self.project_path, proto_tag.attrib["filename"])
+                filename = os.path.realpath(os.path.join(self.project_path, proto_tag.attrib["filename"]))
                 try:
                     proto_frame_item = next((p for p in proto_frame_items if p.protocol.filename == filename))
                 except StopIteration:

--- a/src/urh/util/ProjectManager.py
+++ b/src/urh/util/ProjectManager.py
@@ -353,7 +353,7 @@ class ProjectManager(QObject):
 
             for file_tag in root.findall("open_file"):
                 pos = int(file_tag.attrib["position"])
-                filename = os.path.realpath(os.path.join(self.project_path, file_tag.attrib["name"]))
+                filename = os.path.normpath(os.path.join(self.project_path, file_tag.attrib["name"]))
                 file_names.insert(pos, filename)
 
             QApplication.setOverrideCursor(Qt.WaitCursor)
@@ -380,7 +380,7 @@ class ProjectManager(QObject):
             group = tree_root.child(int(id))
 
             for proto_tag in group_tag.iter("cf_protocol"):
-                filename = os.path.realpath(os.path.join(self.project_path, proto_tag.attrib["filename"]))
+                filename = os.path.normpath(os.path.join(self.project_path, proto_tag.attrib["filename"]))
                 try:
                     proto_frame_item = next((p for p in proto_frame_items if p.protocol.filename == filename))
                 except StopIteration:


### PR DESCRIPTION
This PR fixes a bug where participants do not get assigned properly to previously hidden messages, when loading a project.