### PR TITLE
remove brick wall filter

### DIFF
--- a/src/urh/controller/SignalFrameController.py
+++ b/src/urh/controller/SignalFrameController.py
@@ -162,7 +162,6 @@ class SignalFrameController(QFrame):
         self.ui.sliderSpectrogramMax.valueChanged.connect(self.on_slider_spectrogram_max_value_changed)
         self.ui.gvSpectrogram.y_scale_changed.connect(self.on_gv_spectrogram_y_scale_changed)
         self.ui.gvSpectrogram.bandpass_filter_triggered.connect(self.on_bandpass_filter_triggered)
-        self.ui.gvSpectrogram.brickwall_filter_triggered.connect(self.on_brickwall_filter_triggered)
 
         if self.signal is not None:
             self.ui.gvSignal.save_clicked.connect(self.save_signal)
@@ -1167,15 +1166,6 @@ class SignalFrameController(QFrame):
         signal = self.signal.create_new(new_data=filtered.astype(np.complex64))
         signal.name = self.signal.name + " filtered with f_low={0:.4n} f_high={1:.4n} bw={2:.4n}".format(f_low, f_high,
                                                                                                        filter_bw)
-        self.signal_created.emit(signal)
-        self.unsetCursor()
-
-    @pyqtSlot(float, float)
-    def on_brickwall_filter_triggered(self, f_low: float, f_high: float):
-        self.setCursor(Qt.WaitCursor)
-        filtered = Filter.apply_brick_wall_bandpass(self.signal.data, f_low, f_high)
-        signal = self.signal.create_new(new_data=filtered.astype(np.complex64))
-        signal.name = self.signal.name + " brick wall filtered with f_low={0:.4n} f_high={1:.4n}".format(f_low, f_high)
         self.signal_created.emit(signal)
         self.unsetCursor()
 

--- a/src/urh/signalprocessing/Filter.py
+++ b/src/urh/signalprocessing/Filter.py
@@ -68,23 +68,6 @@ class Filter(object):
         return result[too_much: -too_much]
 
     @classmethod
-    def apply_brick_wall_bandpass(cls, data, f_low, f_high):
-        assert -0.5 <= f_low <= 0.5
-        assert -0.5 <= f_high <= 0.5
-
-        if f_low > f_high:
-            f_low, f_high = f_high, f_low
-
-        spectrum = np.fft.fftshift(np.fft.fft(data))
-
-        lower_border = int((f_low + 0.5) * len(spectrum))
-        higher_border = int((f_high + 0.5) * len(spectrum))
-
-        spectrum[:lower_border] = np.complex(0, 0)
-        spectrum[higher_border:] = np.complex(0, 0)
-        return np.fft.ifft(np.fft.ifftshift(spectrum))
-
-    @classmethod
     def apply_bandpass_filter(cls, data, f_low, f_high, sample_rate: float = None, filter_bw=0.08):
         if sample_rate is not None:
             f_low /= sample_rate

--- a/src/urh/ui/views/SpectrogramGraphicView.py
+++ b/src/urh/ui/views/SpectrogramGraphicView.py
@@ -13,7 +13,6 @@ class SpectrogramGraphicView(ZoomableGraphicView):
     MINIMUM_VIEW_WIDTH = 10
     y_scale_changed = pyqtSignal(float)
     bandpass_filter_triggered = pyqtSignal(float, float)
-    brickwall_filter_triggered = pyqtSignal(float, float)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -58,11 +57,6 @@ class SpectrogramGraphicView(ZoomableGraphicView):
         configure_filter_bw.triggered.connect(self.on_configure_filter_bw_triggered)
         configure_filter_bw.setIcon(QIcon.fromTheme("configure"))
 
-        if self.something_is_selected:
-            menu.addSeparator()
-            create_from_selection_brick_wall = menu.addAction("Apply brick wall filter (may be slow!)")
-            create_from_selection_brick_wall.triggered.connect(self.on_create_from_frequency_selection_brickwall_triggered)
-
         return menu
 
     def zoom_to_selection(self, start: int, end: int):
@@ -85,10 +79,6 @@ class SpectrogramGraphicView(ZoomableGraphicView):
     @pyqtSlot()
     def on_create_from_frequency_selection_triggered(self):
         self.bandpass_filter_triggered.emit(*self.__get_freqs())
-
-    @pyqtSlot()
-    def on_create_from_frequency_selection_brickwall_triggered(self):
-        self.brickwall_filter_triggered.emit(*self.__get_freqs())
 
     def __get_freqs(self):
         sh = self.sceneRect().height()

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -29,7 +29,7 @@ class TestSpectrogram(QtTestCase):
         self.__test_extract_channel(signal_frame, freq1=650, freq2=850, bandwidth="195,312kHz", target_bits="11001101")
         self.__test_extract_channel(signal_frame, freq1=500, freq2=620, bandwidth="117,188kHz", target_bits="10101001")
 
-    def test_channel_separation_brick_wall_filter(self):
+    def test_channel_separation_with_negative_frequency(self):
         super().setUp()
         self.add_signal_to_form("three_channels.complex")
         self.assertEqual(self.form.signal_tab_controller.num_frames, 1)
@@ -38,11 +38,11 @@ class TestSpectrogram(QtTestCase):
         self.__prepare_channel_separation(signal_frame)
 
         self.__test_extract_channel(signal_frame, freq1=650, freq2=850, bandwidth="195,312kHz", target_bits="11001101",
-                                    filter_type="brickwall", center=0.4)
+                                    center=0.4)
         self.__test_extract_channel(signal_frame, freq1=500, freq2=620, bandwidth="117,188kHz", target_bits="10101001",
-                                    filter_type="brickwall", center=0.4)
+                                    center=0.4)
         self.__test_extract_channel(signal_frame, freq1=217, freq2=324, bandwidth="104,492kHz", target_bits="10010111",
-                                    filter_type="brickwall", center=0.4)
+                                    center=0.4)
 
     def __prepare_channel_separation(self, signal_frame):
         self.assertEqual(self.form.signal_tab_controller.num_frames, 1)
@@ -53,8 +53,7 @@ class TestSpectrogram(QtTestCase):
         signal_frame.ui.cbSignalView.setCurrentIndex(2)
         self.assertTrue(signal_frame.spectrogram_is_active)
 
-    def __test_extract_channel(self, signal_frame, freq1, freq2, bandwidth: str, target_bits: str,
-                               filter_type="windowed_sinc", center=None):
+    def __test_extract_channel(self, signal_frame, freq1, freq2, bandwidth: str, target_bits: str, center=None):
         num_frames = self.form.signal_tab_controller.num_frames
 
         signal_frame.ui.spinBoxSelectionStart.setValue(freq1)
@@ -64,12 +63,7 @@ class TestSpectrogram(QtTestCase):
         self.assertEqual(signal_frame.ui.lNumSelectedSamples.text(), str(freq2 - freq1))
         self.assertEqual(signal_frame.ui.lDuration.text().replace(".", ","), bandwidth)
         menu = signal_frame.ui.gvSpectrogram.create_context_menu()
-        if filter_type == "windowed_sinc":
-            create_action = next(action for action in menu.actions() if "bandpass filter" in action.text())
-        elif filter_type == "brickwall":
-            create_action = next(action for action in menu.actions() if "brickwall" in action.text().replace(" ", ""))
-        else:
-            raise ValueError("Unknown filter type")
+        create_action = next(action for action in menu.actions() if "bandpass filter" in action.text())
         create_action.trigger()
 
         self.assertEqual(self.form.signal_tab_controller.num_frames, num_frames + 1)


### PR DESCRIPTION
This PR removes the brick wall filter, as it has a bad performance and can produce undesired results, as stated [here](https://dsp.stackexchange.com/questions/6220/why-is-it-a-bad-idea-to-filter-by-zeroing-out-fft-bins).

The original issue #344 is now fixed in a different way with a20ddb1d33c9c7e7d7a369cec90ff71af4587281, so the original need for the brickwall filter is not present anymore.