### PR TITLE
fix overflow error when modulating very long messages

### DIFF
--- a/src/urh/signalprocessing/Modulator.py
+++ b/src/urh/signalprocessing/Modulator.py
@@ -190,8 +190,13 @@ class Modulator(object):
         else:
             f = self.carrier_freq_hz
 
-        arg = ((2 * np.pi * f * t + phi) * 1j).astype(np.complex64)
-        self.modulated_samples[:total_samples - pause] = a * np.exp(arg)
+        # it may be tempting to do this with complex exp, but exp overflows for large values!
+        # arg = ((2 * np.pi * f * t + phi) * 1j).astype(np.complex64)
+        # self.modulated_samples[:total_samples - pause] = a * np.exp(arg)
+
+        arg = (2 * np.pi * f * t + phi)
+        self.modulated_samples[:total_samples - pause].real = a * np.cos(arg)
+        self.modulated_samples[:total_samples - pause].imag = a * np.sin(arg)
 
     def gauss_fir(self, bt=0.5, filter_width=1):
         """


### PR DESCRIPTION
``` np.exp ``` overflows for values > 300000  ([see here](https://stackoverflow.com/questions/22729223/how-to-calculate-expx-for-really-big-integers-in-python)), so use sin and cos for modulation