### PR TITLE
fix of desktop file to be according the specification

### DIFF
--- a/urh.desktop
+++ b/urh.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-Version=1.9.1
 Name=Universal Radio Hacker
 Comment=investigate wireless protocols like a boss
 Exec=/usr/bin/urh


### PR DESCRIPTION
$ desktop-file-validate ./urh.desktop
./urh.desktop: error: value "1.9.1" for key "Version" in group "Desktop Entry" is not a known version

According to [1]:

"Version of the Desktop Entry Specification that the desktop entry conforms with.
Entries that confirm with this version of the specification should use 1.1.
Note that the version field is not required to be present."

[1] https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>