### PR TITLE
improve initial label types when creating new ones

### DIFF
--- a/src/urh/controller/CompareFrameController.py
+++ b/src/urh/controller/CompareFrameController.py
@@ -445,7 +445,15 @@ class CompareFrameController(QWidget):
     def add_protocol_label(self, start: int, end: int, messagenr: int, proto_view: int, edit_label_name=True):
         # Ensure atleast one Group is active
         start, end = self.proto_analyzer.convert_range(start, end, proto_view, 0, decoded=True, message_indx=messagenr)
-        proto_label = self.proto_analyzer.messages[messagenr].message_type.add_protocol_label(start=start, end=end)
+        message_type = self.proto_analyzer.messages[messagenr].message_type
+        try:
+            used_field_types = [lbl.field_type for lbl in message_type]
+            first_unused_type = next(ft for ft in self.field_types if ft not in used_field_types)
+            name = first_unused_type.caption
+        except (StopIteration, AttributeError):
+            first_unused_type, name = None, None
+
+        proto_label = message_type.add_protocol_label(start=start, end=end, name=name, type=first_unused_type)
 
         self.protocol_label_list_model.update()
         self.protocol_model.update()

--- a/tests/test_simulator_tab_gui.py
+++ b/tests/test_simulator_tab_gui.py
@@ -115,9 +115,9 @@ class TestSimulatorTabGUI(QtTestCase):
         stc.ui.tblViewFieldValues.openPersistentEditor(model.index(0, 3))
         model.setData(model.index(0, 3), "4+5", role=Qt.EditRole)
         self.assertNotEqual(model.data(model.index(0, 3), role=Qt.BackgroundColorRole), constants.ERROR_BG_COLOR)
-        model.setData(model.index(0, 3), "item1.No_name + 42", role=Qt.EditRole)
+        model.setData(model.index(0, 3), "item1.preamble + 42", role=Qt.EditRole)
         self.assertNotEqual(model.data(model.index(0, 3), role=Qt.BackgroundColorRole), constants.ERROR_BG_COLOR)
-        model.setData(model.index(0, 3), "item1.No_name + 42/", role=Qt.EditRole)
+        model.setData(model.index(0, 3), "item1.preamble + 42/", role=Qt.EditRole)
         self.assertEqual(model.data(model.index(0, 3), role=Qt.BackgroundColorRole), constants.ERROR_BG_COLOR)
 
         # external program

--- a/tests/test_text_edit_protocol_view.py
+++ b/tests/test_text_edit_protocol_view.py
@@ -1,10 +1,12 @@
-from PyQt5.QtWidgets import QApplication
-
 from tests.QtTestCase import QtTestCase
+from urh.controller.MainController import MainController
+from urh.signalprocessing.Participant import Participant
 from urh.util.Logger import logger
 
 class TestTextEditProtocolView(QtTestCase):
     def test_create_context_menu(self):
+        assert isinstance(self.form, MainController)
+
         self.add_signal_to_form("esaver.complex")
         self.form.signal_tab_controller.signal_frames[0].ui.cbProtoView.setCurrentIndex(2)
 
@@ -12,12 +14,16 @@ class TestTextEditProtocolView(QtTestCase):
         text_edit = self.form.signal_tab_controller.signal_frames[0].ui.txtEdProto
 
         menu = text_edit.create_context_menu()
-        QApplication.instance().processEvents()
         line_wrap_action = next(action for action in menu.actions() if action.text().startswith("Linewrap"))
         checked = line_wrap_action.isChecked()
         line_wrap_action.trigger()
 
         menu = text_edit.create_context_menu()
-        QApplication.instance().processEvents()
         line_wrap_action = next(action for action in menu.actions() if action.text().startswith("Linewrap"))
         self.assertNotEqual(checked, line_wrap_action.isChecked())
+
+        self.assertEqual(len([action for action in menu.actions() if action.text() == "Participant"]), 0)
+        self.form.project_manager.participants.append(Participant("Alice", "A"))
+        text_edit.selectAll()
+        menu = text_edit.create_context_menu()
+        self.assertEqual(len([action for action in menu.actions() if action.text() == "Participant"]), 1)


### PR DESCRIPTION
When creating a new label in Analysis the initial name for the label is now based on the configured field type. So by default URH now initially names the labels "preamble", "synchronization", "length", ...