### PR TITLE
make message pause configurable in simulator

### DIFF
--- a/src/urh/simulator/Simulator.py
+++ b/src/urh/simulator/Simulator.py
@@ -449,7 +449,7 @@ class Simulator(QObject):
 
     def send_message(self, message, repeat, sender, modulator_index):
         modulator = self.modulators[modulator_index]
-        modulated = modulator.modulate(message.encoded_bits, pause=0)
+        modulated = modulator.modulate(message.encoded_bits, pause=message.pause)
 
         curr_repeat = 0
 

--- a/src/urh/ui/views/SimulatorGraphicsView.py
+++ b/src/urh/ui/views/SimulatorGraphicsView.py
@@ -78,7 +78,7 @@ class SimulatorGraphicsView(QGraphicsView):
             position = QAbstractItemView.BelowItem
 
         message = self.scene().add_message(plain_bits=[0] * num_bits,
-                                           pause=1000000,
+                                           pause=0,
                                            message_type=message_type,
                                            ref_item=ref_item,
                                            position=position)
@@ -285,6 +285,9 @@ class SimulatorGraphicsView(QGraphicsView):
                 swap_part_action.triggered.connect(self.on_swap_part_action_triggered)
                 swap_part_action.setIcon(QIcon.fromTheme("object-flip-horizontal"))
 
+            pause_action = menu.addAction("Set pause ({} samples)".format(self.context_menu_item.model_item.pause))
+            pause_action.triggered.connect(self.on_pause_action_triggered)
+
         menu.addSeparator()
 
         if len(self.scene().get_all_message_items()) > 1:
@@ -343,6 +346,14 @@ class SimulatorGraphicsView(QGraphicsView):
             self.navigate_forward()
         else:
             super().keyPressEvent(event)
+
+    @pyqtSlot()
+    def on_pause_action_triggered(self):
+        p = self.context_menu_item.model_item.pause if isinstance(self.context_menu_item, MessageItem) else 0
+        pause, ok = QInputDialog.getInt(self, self.tr("Enter new Pause Length"), self.tr("Pause Length:"), p, 0)
+        if ok:
+            for msg in self.scene().get_selected_messages():
+                msg.pause = pause
 
     @classmethod
     def add_select_actions_to_menu(cls, menu, scene: SimulatorScene, select_to_trigger, select_from_trigger):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -97,7 +97,7 @@ class TestSimulator(QtTestCase):
         simulator = Simulator(self.stc.simulator_config, self.gtc.modulators, self.stc.sim_expression_parser,
                               self.form.project_manager, sniffer=sniffer, sender=sender)
 
-        pause = 100000
+        pause = 100
         msg_a = SimulatorMessage(part_b,
                                  [1, 0] * 16 + [1, 1, 0, 0] * 8 + [0, 0, 1, 1] * 8 + [1, 0, 1, 1, 1, 0, 0, 1, 1, 1] * 4,
                                  pause=pause, message_type=MessageType("empty_message_type"), source=part_a)
@@ -122,7 +122,7 @@ class TestSimulator(QtTestCase):
 
         current_index = Value("L")
         elapsed = Value("f")
-        target_num_samples = 113600 - pause
+        target_num_samples = 13600 + pause
         receive_process = Process(target=receive, args=(port, current_index, target_num_samples, elapsed))
         receive_process.daemon = True
         receive_process.start()


### PR DESCRIPTION
Now a pause for a message can be configured in simulator flowgraph via right click on a message.
fix #477 