### PR TITLE
allow save and load of binary protocols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
     then
       sudo apt-get update && sudo apt-get -y install python3-zmq python3-pyqt5 python3-numpy python3-psutil
     else
-      pip3 install pyqt5!=5.10 && pip3 install -r data/requirements.txt
+      pip3 install -r data/requirements.txt
     fi
   - |
     if [[ $TRAVIS_PYTHON_VERSION == "3.6"* ]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## v2.2.3 (upcoming)
+New features:
+- allow save and load of binary protocols (``` .bin ``` files) [#488](https://github.com/jopohl/urh/pull/488)
+
+---
+
 ## v2.2.2 (01/07/2018)
 This release removes the ``` config.pxi ``` requirement which caused problems on Arch Linux and Gentoo during installation. More details in PR [#484](https://github.com/jopohl/urh/pull/484).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,3 @@
-image: Visual Studio 2017
-
 environment:
   TWINE_USERNAME:
     secure: qqioSb3Yu/QTOdDKx10sDQ==
@@ -48,7 +46,7 @@ install:
   - 7z x -y "C:\windlls.zip" -o%APPVEYOR_BUILD_FOLDER%\src\urh\dev\native\lib\shared
 
   - pip install -r data\requirements.txt
-  - pip install pytest
+  - pip install pytest pytest-faulthandler
 
 build_script:
   # Build the compiled extension

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2017
+
 environment:
   TWINE_USERNAME:
     secure: qqioSb3Yu/QTOdDKx10sDQ==

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 psutil
-pyqt5!=5.11
+pyqt5
 pyzmq
 cython

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 psutil
-pyqt5
+pyqt5; sys_platform != 'win32'
+pyqt5!=5.11.1,!=5.11.2; sys_platform == 'win32'
 pyzmq
 cython

--- a/src/urh/controller/CompareFrameController.py
+++ b/src/urh/controller/CompareFrameController.py
@@ -424,19 +424,18 @@ class CompareFrameController(QWidget):
         return protocol
 
     def add_protocol_from_file(self, filename: str) -> ProtocolAnalyzer:
-        """
-
-        :rtype: list of ProtocolAnalyzer
-        """
         pa = ProtocolAnalyzer(signal=None, filename=filename)
         pa.message_types = []
 
-        pa.from_xml_file(filename=filename, read_bits=True)
-        for messsage_type in pa.message_types:
-            if messsage_type not in self.proto_analyzer.message_types:
-                if messsage_type.name in (mt.name for mt in self.proto_analyzer.message_types):
-                    messsage_type.name += " (" + os.path.split(filename)[1].rstrip(".xml").rstrip(".proto") + ")"
-                self.proto_analyzer.message_types.append(messsage_type)
+        if filename.endswith(".bin"):
+            pa.from_binary(filename)
+        else:
+            pa.from_xml_file(filename=filename, read_bits=True)
+            for messsage_type in pa.message_types:
+                if messsage_type not in self.proto_analyzer.message_types:
+                    if messsage_type.name in (mt.name for mt in self.proto_analyzer.message_types):
+                        messsage_type.name += " (" + os.path.split(filename)[1].rstrip(".xml").rstrip(".proto") + ")"
+                    self.proto_analyzer.message_types.append(messsage_type)
 
         self.fill_message_type_combobox()
         self.add_protocol(protocol=pa)
@@ -837,8 +836,11 @@ class CompareFrameController(QWidget):
         if not filename:
             return
 
-        self.proto_analyzer.to_xml_file(filename=filename, decoders=self.decodings,
-                                        participants=self.project_manager.participants, write_bits=True)
+        if filename.endswith(".bin"):
+            self.proto_analyzer.to_binary(filename, use_decoded=True)
+        else:
+            self.proto_analyzer.to_xml_file(filename=filename, decoders=self.decodings,
+                                            participants=self.project_manager.participants, write_bits=True)
 
     def show_differences(self, show_differences: bool):
         if show_differences:

--- a/src/urh/controller/MainController.py
+++ b/src/urh/controller/MainController.py
@@ -367,7 +367,7 @@ class MainController(QMainWindow):
                 self.add_signalfile(filename, group_id, enforce_sample_rate=enforce_sample_rate)
             elif filename.endswith(".coco"):
                 self.add_signalfile(filename, group_id, enforce_sample_rate=enforce_sample_rate)
-            elif filename.endswith(".proto") or filename.endswith(".proto.xml"):
+            elif filename.endswith(".proto") or filename.endswith(".proto.xml") or filename.endswith(".bin"):
                 self.add_protocol_file(filename)
             elif filename.endswith(".wav"):
                 try:

--- a/src/urh/util/FileOperator.py
+++ b/src/urh/util/FileOperator.py
@@ -39,15 +39,16 @@ def get_open_dialog(directory_mode=False, parent=None, name_filter="full") -> QF
                           "Complex16 signed (*.complex16s);;" \
                           "Wave (*.wav);;" \
                           "Protocols (*.proto.xml *.proto);;" \
+                          "Binary Protocols (*.bin);;" \
                           "Fuzzprofiles (*.fuzz.xml *.fuzz);;" \
                           "Simulator (*.sim.xml *.sim)" \
                           "Plain bits (*.txt);;" \
                           "Tar Archives (*.tar *.tar.gz *.tar.bz2);;" \
                           "Zip Archives (*.zip)"
         elif name_filter == "proto":
-            name_filter = "Protocols (*.proto.xml *.proto);;"
+            name_filter = "Protocols (*.proto.xml *.proto);; Binary Protocols (*.bin)"
         elif name_filter == "fuzz":
-            name_filter = "Fuzzprofiles (*.fuzz.xml *.fuzz);;"
+            name_filter = "Fuzzprofiles (*.fuzz.xml *.fuzz)"
         elif name_filter == "simulator":
             name_filter = "Simulator (*.sim.xml *.sim)"
 
@@ -111,7 +112,7 @@ def get_save_file_name(initial_name: str, wav_only=False, caption="Save signal")
     elif caption == "Export spectrogram":
         name_filter = "Frequency Time (*.ft);;Frequency Time Amplitude (*.fta)"
     else:
-        name_filter = "Protocols (*.proto.xml *.proto);;All files (*)"
+        name_filter = "Protocols (*.proto.xml *.proto);;Binary Protocol (*.bin);;All files (*)"
 
     filename = None
     dialog = QFileDialog()

--- a/tests/test_protocol_analyzer.py
+++ b/tests/test_protocol_analyzer.py
@@ -1,6 +1,9 @@
+import os
+import tempfile
 import unittest
 
 from tests.utils_testing import get_path_for_data_file
+from urh.signalprocessing.Message import Message
 from urh.signalprocessing.ProtocolAnalyzer import ProtocolAnalyzer
 from urh.signalprocessing.Signal import Signal
 
@@ -50,3 +53,15 @@ class TestProtocolAnalyzer(unittest.TestCase):
         self.assertGreater(messages[1].rssi, messages[2].rssi)
         self.assertLess(messages[2].rssi, messages[3].rssi)
         self.assertLess(messages[-2].rssi, messages[-1].rssi)
+
+    def test_binary_format(self):
+        pa = ProtocolAnalyzer(None)
+        pa.messages.append(Message([1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1], 0, pa.default_message_type))
+        pa.messages.append(Message([1, 1, 1, 0, 1], 0, pa.default_message_type))
+
+        filename = os.path.join(tempfile.gettempdir(), "test_proto.bin")
+        pa.to_binary(filename, use_decoded=True)
+
+        pa.from_binary(filename)
+        self.assertEqual(len(pa.messages), 3)
+        self.assertEqual(pa.plain_bits_str[2], "111000111001101111101000")


### PR DESCRIPTION
This PR aims to fix #487 . Protocols can now be saved in binary format (``` .bin ``` from Analysis via the save button:
![bildschirmfoto_2018-07-03_11-12-23](https://user-images.githubusercontent.com/18219846/42210733-0ad0e7ae-7eb2-11e8-846f-10486edef144.png)

Vice versa, loading a ``` .bin ``` protocol is possible via the load button right next to the save button or using File -> Open.