### PR TITLE
Update SDRPlay native plugin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
 
 build_script:
   # Build the compiled extension
-  - python setup.py build_ext --inplace > build_log.txt
+  - python setup.py build_ext --inplace
 
 test_script:
   - python src\urh\main.py --version

--- a/src/urh/dev/native/lib/csdrplay.pxd
+++ b/src/urh/dev/native/lib/csdrplay.pxd
@@ -112,7 +112,7 @@ cdef extern from "mirsdrapi-rsp.h":
        float max;
        float min;
 
-    ctypedef void mir_sdr_StreamCallback_t(short *xi, short *xq, unsigned int firstSampleNum, int grChanged, int rfChanged, int fsChanged, unsigned int numSamples, unsigned int reset, void *cbContext)
+    ctypedef void mir_sdr_StreamCallback_t(short *xi, short *xq, unsigned int firstSampleNum, int grChanged, int rfChanged, int fsChanged, unsigned int numSamples, unsigned int reset,unsigned int hwRemoved, void *cbContext)
     ctypedef void mir_sdr_GainChangeCallback_t(unsigned int gRdB, unsigned int lnaGRdB, void *cbContext)
 
     mir_sdr_ErrT mir_sdr_ReadPacket(short *xi, short *xq, unsigned int *firstSampleNum, int *grChanged, int *rfChanged, int *fsChanged)

--- a/src/urh/dev/native/lib/sdrplay.pyx
+++ b/src/urh/dev/native/lib/sdrplay.pyx
@@ -20,7 +20,7 @@ global reset_rx, reset_rx_request_received
 reset_rx = False
 reset_rx_request_received = False
 
-cdef void _rx_stream_callback(short *xi, short *xq, unsigned int firstSampleNum, int grChanged, int rfChanged, int fsChanged, unsigned int numSamples, unsigned int reset, void *cbContext):
+cdef void _rx_stream_callback(short *xi, short *xq, unsigned int firstSampleNum, int grChanged, int rfChanged, int fsChanged, unsigned int numSamples, unsigned int reset, unsigned int hwRemoved, void *cbContext):
     cdef float* data = <float *>malloc(2*numSamples * sizeof(float))
 
     cdef unsigned int i = 0
@@ -93,8 +93,8 @@ cpdef get_devices():
 cdef int calculate_gain_reduction(int gain):
     """
     Calculate gain reduction for API. Highest possible gain leads to lowest possible gain reduction
-    :param gain: 
-    :return: 
+    :param gain:
+    :return:
     """
     gain = max(20, min(gain, 59))
     return 79 - gain


### PR DESCRIPTION
The signature for "mir_sdr_StreamCallback_t" is changed in the latest SDRPlay API.
This breaks the compiling (on file "src/urh/dev/native/lib/sdrplay.cpp:3856")
One argument is added before the latest arg of the callback.

Latest SDRPlay API spec is available here: https://www.sdrplay.com/docs/SDRplay_SDR_API_Specification.pdf

By the way, here I am talking about API 2.x series. SDRPlay is working on the 3.0 API which has a different design (https://www.sdrplay.com/community/viewtopic.php?f=6&t=3345)
