### PR TITLE
ignore case for hex search 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v2.3.1 (upcoming)
+### Improvements
+- ignore case when searching for hex values in analysis [#544](https://github.com/jopohl/urh/pull/544)
+
 ## v2.3.0 (28/09/2018)
 ### New features
 - added native support for BladeRF [#524](https://github.com/jopohl/urh/pull/524)

--- a/src/urh/models/TableModel.py
+++ b/src/urh/models/TableModel.py
@@ -314,6 +314,9 @@ class TableModel(QAbstractTableModel):
 
     def find_protocol_value(self, value):
         self.search_results.clear()
+        if self.proto_view == 1:
+            value = value.lower()
+
         self.search_value = value
 
         if len(value) == 0:


### PR DESCRIPTION
fix #543 

So wen can search e.g. for "CAFE" as well as for "cafe"