### PR TITLE
allow more gains for rtlsdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## v2.4.2 (upcoming)
 ### New features
-- enhance settings for RTL-SDR [#561](https://github.com/jopohl/urh/pull/561)
+- enhance settings for RTL-SDR [#561](https://github.com/jopohl/urh/pull/561) + [#566](https://github.com/jopohl/urh/pull/566)
 - ergonomic improvements [#564](https://github.com/jopohl/urh/pull/564)
 
 ### Bugfixes

--- a/src/urh/dev/config.py
+++ b/src/urh/dev/config.py
@@ -74,7 +74,7 @@ DEVICE_CONFIG["RTL-SDR"] = {
     "center_freq": dev_range(start=0.1 * M, stop=2200 * M, step=1),
     "sample_rate": dev_range(start=1, stop=int(3.2 * M), step=1),
     "bandwidth": dev_range(start=1, stop=int(3.2 * M), step=1),
-    "rx_rf_gain": list(range(-10, 51)),  # CAUTION: API is *10 so e.g. 1 needs to be given as 10 to API
+    "rx_rf_gain": list(range(-100, 500)),
     "direct_sampling": ["disabled", "I-ADC input enabled", "Q-ADC input enabled"],
     "freq_correction": dev_range(start=-1 * 10 ** 3, stop=1 * 10 ** 3, step=1)
 }

--- a/src/urh/dev/config.py
+++ b/src/urh/dev/config.py
@@ -74,7 +74,7 @@ DEVICE_CONFIG["RTL-SDR"] = {
     "center_freq": dev_range(start=0.1 * M, stop=2200 * M, step=1),
     "sample_rate": dev_range(start=1, stop=int(3.2 * M), step=1),
     "bandwidth": dev_range(start=1, stop=int(3.2 * M), step=1),
-    "rx_rf_gain": list(range(-4, 51)),  # CAUTION: API is *10 so e.g. 1 needs to be given as 10 to API
+    "rx_rf_gain": list(range(-10, 51)),  # CAUTION: API is *10 so e.g. 1 needs to be given as 10 to API
     "direct_sampling": ["disabled", "I-ADC input enabled", "Q-ADC input enabled"],
     "freq_correction": dev_range(start=-1 * 10 ** 3, stop=1 * 10 ** 3, step=1)
 }

--- a/src/urh/dev/native/Device.py
+++ b/src/urh/dev/native/Device.py
@@ -72,6 +72,18 @@ class Device(object):
 
         if method_name:
             try:
+                try:
+                    check_method_name = cls.DEVICE_METHODS[tag+"_get_allowed_values"]
+                    allowed_values = getattr(cls.DEVICE_LIB, check_method_name)()
+                    next_allowed = min(allowed_values, key=lambda x: abs(x-value))
+                    if value != next_allowed:
+                        ctrl_connection.send("{}: {} not in range of supported values. Assuming {}".format(
+                            tag, value, next_allowed
+                        ))
+                        value = next_allowed
+                except (KeyError, AttributeError):
+                    pass
+
                 ret = getattr(cls.DEVICE_LIB, method_name)(value)
                 ctrl_connection.send("{0} to {1}:{2}".format(tag, value, ret))
             except AttributeError as e:

--- a/src/urh/dev/native/RTLSDR.py
+++ b/src/urh/dev/native/RTLSDR.py
@@ -15,6 +15,7 @@ class RTLSDR(Device):
     DEVICE_METHODS = Device.DEVICE_METHODS.copy()
     DEVICE_METHODS.update({
         Device.Command.SET_RF_GAIN.name: "set_tuner_gain",
+        Device.Command.SET_RF_GAIN.name+"_get_allowed_values": "get_tuner_gains",
         Device.Command.SET_BANDWIDTH.name: "set_tuner_bandwidth",
         Device.Command.SET_FREQUENCY_CORRECTION.name: "set_freq_correction",
         Device.Command.SET_DIRECT_SAMPLING_MODE.name: "set_direct_sampling"
@@ -73,7 +74,7 @@ class RTLSDR(Device):
                             (self.Command.SET_BANDWIDTH.name, self.bandwidth),
                             (self.Command.SET_FREQUENCY_CORRECTION.name, self.freq_correction),
                             (self.Command.SET_DIRECT_SAMPLING_MODE.name, self.direct_sampling_mode),
-                            (self.Command.SET_RF_GAIN.name, 10 * self.gain),
+                            (self.Command.SET_RF_GAIN.name, self.gain),
                             ("identifier", self.device_number)])
 
     @property
@@ -85,9 +86,6 @@ class RTLSDR(Device):
             super().set_device_bandwidth(bandwidth)
         else:
             logger.warning("Setting the bandwidth is not supported by your RTL-SDR driver version.")
-
-    def set_device_gain(self, gain):
-        super().set_device_gain(10 * gain)
 
     @staticmethod
     def unpack_complex(buffer):

--- a/src/urh/dev/native/RTLSDRTCP.py
+++ b/src/urh/dev/native/RTLSDRTCP.py
@@ -1,10 +1,10 @@
+import select
+import socket
+
 import numpy as np
 
 from urh.dev.native.Device import Device
 from urh.util.Logger import logger
-
-import socket
-import select
 
 
 class RTLSDRTCP(Device):
@@ -29,8 +29,7 @@ class RTLSDRTCP(Device):
             sdr.set_parameter("freqCorrection", int(freq_correction), ctrl_connection)
             sdr.set_parameter("directSampling", int(direct_sampling_mode), ctrl_connection)
             # Gain has to be set last, otherwise it does not get considered by RTL-SDR
-            sdr.set_parameter("tunerGain", 10 * int(gain),
-                              ctrl_connection)  # gain is multiplied by 10 because of rtlsdr-API
+            sdr.set_parameter("tunerGain", int(gain), ctrl_connection)
             exit_requested = False
 
             while not exit_requested:
@@ -63,11 +62,11 @@ class RTLSDRTCP(Device):
 
         elif tag == self.Command.SET_RF_GAIN.name:
             logger.info("RTLSDRTCP: Set tuner gain to {0}".format(int(value)))
-            return self.set_parameter("tunerGain", 10 * int(value), ctrl_connection)  # calculate *10 for API
+            return self.set_parameter("tunerGain", int(value), ctrl_connection)
 
         elif tag == self.Command.SET_IF_GAIN.name:
             logger.info("RTLSDRTCP: Set if gain to {0}".format(int(value)))
-            return self.set_parameter("tunerIFGain", 10 * int(value), ctrl_connection)  # calculate *10 for API
+            return self.set_parameter("tunerIFGain", int(value), ctrl_connection)
 
         elif tag == self.Command.SET_SAMPLE_RATE.name:
             logger.info("RTLSDRTCP: Set sample_rate to {0}".format(int(value)))

--- a/src/urh/dev/native/lib/rtlsdr.pyx
+++ b/src/urh/dev/native/lib/rtlsdr.pyx
@@ -178,7 +178,10 @@ cpdef list get_tuner_gains():
     cdef int*gains = <int *> malloc(num_gains * sizeof(int))
     crtlsdr.rtlsdr_get_tuner_gains(_c_device, gains)
 
-    return [gains[i] for i in range(num_gains)]
+    try:
+        return [gains[i] for i in range(num_gains)]
+    finally:
+        free(gains)
 
 cpdef int set_tuner_gain(int gain):
     """


### PR DESCRIPTION
This PR aims to fix #565. Now all possible gains for all possible RTL-SDRs are supported and the gains are corrected via a call to ```get_tuner_gains``` if needed.