### PR TITLE
show save button when action on saved signal gets undone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 ## v2.4.3 (upcoming)
 ### Bugfixes
-- Do not add URH to autostart on windows [#569](https://github.com/jopohl/urh/pull/569)
+- do not add URH to autostart on windows [#569](https://github.com/jopohl/urh/pull/569)
+- save button was not shown when change on saved signal was undone [#571](https://github.com/jopohl/urh/pull/571)
 
 ## v2.4.2 (11/11/2018)
 ### New features

--- a/src/urh/controller/widgets/SignalFrame.py
+++ b/src/urh/controller/widgets/SignalFrame.py
@@ -1084,6 +1084,12 @@ class SignalFrame(QFrame):
         else:
             font.setBold(False)
             self.ui.btnSaveSignal.hide()
+            for i in range(self.undo_stack.count()):
+                cmd = self.undo_stack.command(i)
+                if isinstance(cmd, EditSignalAction):
+                    # https://github.com/jopohl/urh/issues/570
+                    cmd.signal_was_changed = True
+
         self.ui.lineEditSignalName.setFont(font)
 
     @pyqtSlot()


### PR DESCRIPTION
fix #570 