### PR TITLE
fix center detection crash on special signals (fix #615)

### DIFF
--- a/src/urh/ainterpretation/AutoInterpretation.py
+++ b/src/urh/ainterpretation/AutoInterpretation.py
@@ -204,7 +204,11 @@ def detect_center(rectangular_signal: np.ndarray, max_size=None):
     # If a signal has low variance we need to be more accurate at center detection
     hist_step = float(np.var(rect))
 
-    y, x = np.histogram(rect, bins=np.arange(hist_min, hist_max + hist_step, hist_step))
+    try:
+        y, x = np.histogram(rect, bins=np.arange(hist_min, hist_max + hist_step, hist_step))
+    except ZeroDivisionError:
+        # For a segment with zero variance (constant line) it is not possible to find a center
+        return None
 
     num_values = 2
     most_common_levels = []


### PR DESCRIPTION
If a signal has segments with zero variance i.e. constant lines,
the center detection crashes because the histogram can not be created.
This fix catches the ZeroDivision error and returns None in that case.