### PR TITLE
Fix crash when showing diff of empty protocol

### DIFF
--- a/src/urh/controller/CompareFrameController.py
+++ b/src/urh/controller/CompareFrameController.py
@@ -1386,7 +1386,7 @@ class CompareFrameController(QWidget):
 
     @pyqtSlot(int)
     def on_ref_index_changed(self, new_ref_index: int):
-        if new_ref_index != -1:
+        if new_ref_index != -1 and self.protocol_model.row_count:
             hide_correction = 0
             for i in range(0, self.protocol_model.row_count):
                 if self.ui.tblViewProtocol.isRowHidden((new_ref_index + i) % self.protocol_model.row_count):


### PR DESCRIPTION
Pressing the checkboxes "Mark diffs in protocol", "Show only diffs in protocol" or "Show only labels in protocol" in the Analysis tab would crash the app if no rows are available.

Traceback (most recent call last):
  File "/urh/src/urh/controller/CompareFrameController.py", line 1398, in on_ref_index_changed
    self.protocol_model.refindex = (new_ref_index + hide_correction) % self.protocol_model.row_count
ZeroDivisionError: integer division or modulo by zero
