### PR TITLE
Add compatibility with Macports

### DIFF
--- a/src/urh/dev/native/ExtensionHelper.py
+++ b/src/urh/dev/native/ExtensionHelper.py
@@ -123,7 +123,11 @@ def get_device_extensions_and_extras(library_dirs=None):
     if sys.platform == "darwin":
         # On Mac OS X clang is by default not smart enough to search in the lib dir
         # see: https://github.com/jopohl/urh/issues/173
+        if os.path.isdir("/opt/local/lib"):
+            library_dirs.append("/opt/local/lib")
         library_dirs.append("/usr/local/lib")
+        if os.path.isdir("/opt/local/include"):
+            include_dirs.append("/opt/local/include")
 
     result = []
 


### PR DESCRIPTION
This checks for the existence of Macports-specific library and include paths and adds them to the compiler flags, so that the native modules detect SDR libraries as expected.