### PR TITLE
fix error with message length divisor

### DIFF
--- a/data/ui/advanced_modulation_settings.ui
+++ b/data/ui/advanced_modulation_settings.ui
@@ -70,6 +70,9 @@
         <property name="minimum">
          <number>1</number>
         </property>
+        <property name="maximum">
+         <number>999999999</number>
+        </property>
        </widget>
       </item>
      </layout>

--- a/src/urh/controller/widgets/SignalFrame.py
+++ b/src/urh/controller/widgets/SignalFrame.py
@@ -1248,7 +1248,7 @@ class SignalFrame(QFrame):
 
     @pyqtSlot(int)
     def on_message_length_divisor_edited(self, message_length_divisor: int):
-        if self.signal.pause_threshold != message_length_divisor:
+        if self.signal.message_length_divisor != message_length_divisor:
             message_length_divisor_action = ChangeSignalParameter(signal=self.signal, protocol=self.proto_analyzer,
                                                                   parameter_name="message_length_divisor",
                                                                   parameter_value=message_length_divisor)

--- a/src/urh/ui/ui_advanced_modulation_settings.py
+++ b/src/urh/ui/ui_advanced_modulation_settings.py
@@ -6,6 +6,7 @@
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+
 class Ui_DialogAdvancedModSettings(object):
     def setupUi(self, DialogAdvancedModSettings):
         DialogAdvancedModSettings.setObjectName("DialogAdvancedModSettings")
@@ -37,6 +38,7 @@ class Ui_DialogAdvancedModSettings(object):
         self.verticalLayout_2.addWidget(self.label_2)
         self.spinBoxMessageLengthDivisor = QtWidgets.QSpinBox(self.groupBox_2)
         self.spinBoxMessageLengthDivisor.setMinimum(1)
+        self.spinBoxMessageLengthDivisor.setMaximum(999999999)
         self.spinBoxMessageLengthDivisor.setObjectName("spinBoxMessageLengthDivisor")
         self.verticalLayout_2.addWidget(self.spinBoxMessageLengthDivisor)
         self.verticalLayout_3.addWidget(self.groupBox_2)
@@ -60,4 +62,5 @@ class Ui_DialogAdvancedModSettings(object):
         self.spinBoxPauseThreshold.setSpecialValueText(_translate("DialogAdvancedModSettings", "Disable"))
         self.groupBox_2.setTitle(_translate("DialogAdvancedModSettings", "Message Length Divisor"))
         self.label_2.setText(_translate("DialogAdvancedModSettings", "<html><head/><body><p>With the message <span style=\" font-weight:600;\">divisor length</span> you can control the minimum message length in a flexible way. URH will try to demodulate signals in such a way, that the resulting message has a number of bits that is divisble by the configured divisor. <br/><br/><span style=\" font-style:italic;\">How does the zero padding work? Remaining zero bits are taken from the pause behind the message if possible.</span></p></body></html>"))
+
 


### PR DESCRIPTION
This fixes an error where the message divisor length was not applied correctly, when configured in the dialog. This furthermore increases the maximum for the divisor length and is therefore a fix #638 .