### PR TITLE
Adding compile flag for MacOS and c++ complex library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def get_package_data():
 def get_extensions():
     filenames = [os.path.splitext(f)[0] for f in os.listdir("src/urh/cythonext") if f.endswith(".pyx")]
     extensions = [Extension("urh.cythonext." + f, ["src/urh/cythonext/" + f + ".pyx"],
-                            extra_compile_args=[OPEN_MP_FLAG],
+                            extra_compile_args=[OPEN_MP_FLAG, "-stdlib=libc++"],
                             extra_link_args=[OPEN_MP_FLAG],
                             language="c++") for f in filenames]
 


### PR DESCRIPTION
Trying to compile urh from source or run the main.py executable for MacOs Mojave 10.14 and Xcode version 10.2.1, I was getting errors regarding the c++ complex library. To resolve the issue, I added a flag on the setup.py file. However, I still get a number of warnings.