### PR TITLE
docs: fix simple typo, srceen -> screen

### DIFF
--- a/src/urh/controller/dialogs/ModulatorDialog.py
+++ b/src/urh/controller/dialogs/ModulatorDialog.py
@@ -68,7 +68,7 @@ class ModulatorDialog(QDialog):
         self.set_bits_per_symbol_enabled_status()
         self.set_modulation_profile_status()
 
-        # Ensure full srceen shown after resize
+        # Ensure full screen shown after resize
         QTimer.singleShot(100, self.show_full_scene)
 
     def __cur_selected_mod_type(self):


### PR DESCRIPTION
There is a small typo in src/urh/controller/dialogs/ModulatorDialog.py.

Should read `screen` rather than `srceen`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md