### PR TITLE
Use list for checksum data_ranges

### DIFF
--- a/src/urh/awre/FormatFinder.py
+++ b/src/urh/awre/FormatFinder.py
@@ -244,7 +244,7 @@ class FormatFinder(object):
         if field_type.function == FieldType.Function.CHECKSUM:
             assert isinstance(label, ChecksumLabel)
             assert isinstance(common_range, ChecksumRange)
-            label.data_ranges = [(common_range.data_range_bit_start, common_range.data_range_bit_end)]
+            label.data_ranges = [[common_range.data_range_bit_start, common_range.data_range_bit_end]]
 
             if isinstance(common_range.crc, WSPChecksum):
                 label.category = ChecksumLabel.Category.wsp


### PR DESCRIPTION
The auto created "checksum" field/label is initialized with a list with a single tuple for data ranges, which causes URH to crash if the auto guessed range is modified at any point later via CheckSum widget. 
The `__data_ranges` should be `list[list[int, int]]`

Fixes #840 
