### PR TITLE
add bias tee check box on device settings

### DIFF
--- a/src/urh/controller/widgets/DeviceSettingsWidget.py
+++ b/src/urh/controller/widgets/DeviceSettingsWidget.py
@@ -363,6 +363,7 @@ class DeviceSettingsWidget(QWidget):
         self.ui.comboBoxAntenna.currentIndexChanged.emit(self.ui.comboBoxAntenna.currentIndex())
         self.ui.comboBoxChannel.currentIndexChanged.emit(self.ui.comboBoxChannel.currentIndex())
         self.ui.checkBoxDCCorrection.clicked.emit(self.ui.checkBoxDCCorrection.isChecked())
+        self.ui.checkBoxBiasTee.clicked.emit(self.ui.checkBoxBiasTee.isChecked())
 
     def emit_device_parameters_changed(self):
         settings = {"name": str(self.device.name)}

--- a/src/urh/dev/config.py
+++ b/src/urh/dev/config.py
@@ -37,6 +37,7 @@ DEVICE_CONFIG["BladeRF"] = {
     "tx_channel": ["TX1", "TX2"],
     "tx_rf_gain": list(range(0, 61)),
     "rx_rf_gain": list(range(0, 61)),
+    "bias_tee_enabled": [False, True]
 }
 
 # https://github.com/mossmann/hackrf/wiki/HackRF-One#features

--- a/src/urh/dev/native/BladeRF.py
+++ b/src/urh/dev/native/BladeRF.py
@@ -17,7 +17,8 @@ class BladeRF(Device):
     DEVICE_METHODS = Device.DEVICE_METHODS.copy()
     DEVICE_METHODS.update({
         Device.Command.SET_RF_GAIN.name: "set_gain",
-        Device.Command.SET_CHANNEL_INDEX.name: "set_channel"
+        Device.Command.SET_CHANNEL_INDEX.name: "set_channel",
+        Device.Command.SET_BIAS_TEE_ENABLED.name: "set_bias_tee"
     })
 
     DATA_TYPE = np.int16
@@ -96,6 +97,7 @@ class BladeRF(Device):
                             (self.Command.SET_SAMPLE_RATE.name, self.sample_rate),
                             (self.Command.SET_BANDWIDTH.name, self.bandwidth),
                             (self.Command.SET_RF_GAIN.name, self.gain),
+                            (self.Command.SET_BIAS_TEE_ENABLED.name, self.bias_tee_enabled),
                             ("identifier", self.device_serial)])
 
     @staticmethod

--- a/src/urh/dev/native/lib/bladerf.pyx
+++ b/src/urh/dev/native/lib/bladerf.pyx
@@ -138,10 +138,12 @@ cpdef bladerf_frequency get_center_freq():
     return result
 
 cpdef int set_bias_tee(on_or_off):
+  IF BLADERF_API_VERSION >= 1.91:
     cdef bool bias_tee = 1 if on_or_off else 0
     return bladerf_set_bias_tee(_c_device, get_current_bladerf_channel(), bias_tee)
 
 cpdef int get_bias_tee():
+  IF BLADERF_API_VERSION >= 1.91:
     cdef bool result = 0
     err = bladerf_get_bias_tee(_c_device, get_current_bladerf_channel(), &result)
 

--- a/src/urh/dev/native/lib/bladerf.pyx
+++ b/src/urh/dev/native/lib/bladerf.pyx
@@ -137,6 +137,19 @@ cpdef bladerf_frequency get_center_freq():
 
     return result
 
+cpdef int set_bias_tee(on_or_off):
+    cdef bool bias_tee = 1 if on_or_off else 0
+    return bladerf_set_bias_tee(_c_device, get_current_bladerf_channel(), bias_tee)
+
+cpdef int get_bias_tee():
+    cdef bool result = 0
+    err = bladerf_get_bias_tee(_c_device, get_current_bladerf_channel(), &result)
+
+    if err != 0:
+        return 0
+
+    return result
+
 cpdef int prepare_sync():
     enable_module()
     return bladerf_sync_config(_c_device, get_current_channel_layout(), BLADERF_FORMAT_SC16_Q11, 32, 2048, 16, 100)

--- a/src/urh/dev/native/lib/bladerf.pyx
+++ b/src/urh/dev/native/lib/bladerf.pyx
@@ -141,16 +141,20 @@ cpdef int set_bias_tee(on_or_off):
   IF BLADERF_API_VERSION >= 2:
     cdef bool bias_tee = 1 if on_or_off else 0
     return bladerf_set_bias_tee(_c_device, get_current_bladerf_channel(), bias_tee)
+  ELSE:
+    return -1
 
 cpdef int get_bias_tee():
   IF BLADERF_API_VERSION >= 2:
     cdef bool result = 0
     err = bladerf_get_bias_tee(_c_device, get_current_bladerf_channel(), &result)
-
-    if err != 0:
-        return 0
+    if err < 0:
+      return err
 
     return result
+  ELSE:
+    return -1
+
 
 cpdef int prepare_sync():
     enable_module()

--- a/src/urh/dev/native/lib/bladerf.pyx
+++ b/src/urh/dev/native/lib/bladerf.pyx
@@ -138,12 +138,12 @@ cpdef bladerf_frequency get_center_freq():
   return result
 
 cpdef int set_bias_tee(on_or_off):
-  IF BLADERF_API_VERSION >= 1.91:
+  IF BLADERF_API_VERSION >= 2:
     cdef bool bias_tee = 1 if on_or_off else 0
     return bladerf_set_bias_tee(_c_device, get_current_bladerf_channel(), bias_tee)
 
 cpdef int get_bias_tee():
-  IF BLADERF_API_VERSION >= 1.91:
+  IF BLADERF_API_VERSION >= 2:
     cdef bool result = 0
     err = bladerf_get_bias_tee(_c_device, get_current_bladerf_channel(), &result)
 

--- a/src/urh/dev/native/lib/bladerf.pyx
+++ b/src/urh/dev/native/lib/bladerf.pyx
@@ -129,13 +129,18 @@ cpdef int set_center_freq(bladerf_frequency frequency):
     return bladerf_set_frequency(_c_device, get_current_bladerf_channel(), frequency)
 
 cpdef bladerf_frequency get_center_freq():
+  IF BLADERF_API_VERSION >= 2:
     cdef bladerf_frequency result = 0
-    err = bladerf_get_frequency(_c_device, get_current_bladerf_channel(), &result)
+  ELIF BLADERF_API_VERSION >= 1.91:
+    cdef uint64_t result = 0
+  ELSE:
+    cdef unsigned int result = 0
+  err = bladerf_get_frequency(_c_device, get_current_bladerf_channel(), &result)
 
-    if err != 0:
-        return 0
+  if err != 0:
+      return 0
 
-    return result
+  return result
 
 cpdef int set_bias_tee(on_or_off):
   IF BLADERF_API_VERSION >= 1.91:

--- a/src/urh/dev/native/lib/bladerf.pyx
+++ b/src/urh/dev/native/lib/bladerf.pyx
@@ -129,12 +129,7 @@ cpdef int set_center_freq(bladerf_frequency frequency):
     return bladerf_set_frequency(_c_device, get_current_bladerf_channel(), frequency)
 
 cpdef bladerf_frequency get_center_freq():
-  IF BLADERF_API_VERSION >= 2:
-    cdef bladerf_frequency result = 0
-  ELIF BLADERF_API_VERSION >= 1.91:
-    cdef uint64_t result = 0
-  ELSE:
-    cdef unsigned int result = 0
+  cdef bladerf_frequency result = 0
   err = bladerf_get_frequency(_c_device, get_current_bladerf_channel(), &result)
 
   if err != 0:

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -1,11 +1,6 @@
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 from libcpp cimport bool
 
-IF BLADERF_API_VERSION >= 1.91:
-    ctypedef uint64_t bladerf_frequency
-ELSE:
-    ctypedef unsigned int bladerf_frequency
-    
 cdef extern from "libbladeRF.h":
     struct bladerf
 
@@ -99,16 +94,19 @@ cdef extern from "libbladeRF.h":
         int bladerf_set_bandwidth(bladerf *dev, bladerf_module module, unsigned int bandwidth, unsigned int *actual)
         int bladerf_get_bandwidth(bladerf *dev, bladerf_module module, unsigned int *bandwidth)
 
+    IF BLADERF_API_VERSION >= 2:
+      ctypedef uint64_t bladerf_frequency
+      int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
+      int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
+    ELSE:
+      ctypedef unsigned int bladerf_frequency
+
     IF BLADERF_API_VERSION >= 1.91:
         int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, uint64_t frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_channel ch, uint64_t *frequency)
     ELSE:
         int bladerf_set_frequency(bladerf *dev, bladerf_module module, unsigned int frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_module module, unsigned int *frequency)
-
-    IF BLADERF_API_VERSION >= 1.91:
-      int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
-      int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
 
     ctypedef enum bladerf_format:
         BLADERF_FORMAT_SC16_Q11

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -104,6 +104,10 @@ cdef extern from "libbladeRF.h":
         int bladerf_set_frequency(bladerf *dev, bladerf_module module, unsigned int frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_module module, unsigned int *frequency)
 
+    IF BLADERF_API_VERSION >= 2:
+        int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
+        int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
+
     ctypedef enum bladerf_format:
         BLADERF_FORMAT_SC16_Q11
         BLADERF_FORMAT_SC16_Q11_META

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -95,11 +95,11 @@ cdef extern from "libbladeRF.h":
         int bladerf_get_bandwidth(bladerf *dev, bladerf_module module, unsigned int *bandwidth)
 
     IF BLADERF_API_VERSION >= 2:
+        int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, bladerf_frequency frequency)
+        int bladerf_get_frequency(bladerf *dev, bladerf_channel ch, bladerf_frequency *frequency)
+    IF BLADERF_API_VERSION >= 1.91:
         int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, uint64_t frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_channel ch, uint64_t *frequency)
-    ELIF BLADERF_API_VERSION >= 1.91:
-        int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, unsigned int frequency)
-        int bladerf_get_frequency(bladerf *dev, bladerf_channel ch, unsigned int *frequency)
     ELSE:
         int bladerf_set_frequency(bladerf *dev, bladerf_module module, unsigned int frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_module module, unsigned int *frequency)

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -104,9 +104,9 @@ cdef extern from "libbladeRF.h":
         int bladerf_set_frequency(bladerf *dev, bladerf_module module, unsigned int frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_module module, unsigned int *frequency)
 
-    IF BLADERF_API_VERSION >= 2:
-        int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
-        int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
+    IF BLADERF_API_VERSION >= 1.91:
+      int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
+      int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
 
     ctypedef enum bladerf_format:
         BLADERF_FORMAT_SC16_Q11

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -95,11 +95,8 @@ cdef extern from "libbladeRF.h":
         int bladerf_get_bandwidth(bladerf *dev, bladerf_module module, unsigned int *bandwidth)
 
     IF BLADERF_API_VERSION >= 2:
-      ctypedef uint64_t bladerf_frequency
       int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
       int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
-    ELSE:
-      ctypedef unsigned int bladerf_frequency
 
     IF BLADERF_API_VERSION >= 1.91:
         int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, uint64_t frequency)
@@ -128,6 +125,11 @@ cdef extern from "libbladeRF.h":
 
     int bladerf_sync_rx(bladerf *dev, void *samples, unsigned int num_samples, bladerf_metadata *metadata, unsigned int timeout_ms)
     int bladerf_sync_tx(bladerf *dev, const void *samples, unsigned int num_samples, bladerf_metadata *metadata, unsigned int timeout_ms)
+
+IF BLADERF_API_VERSION >= 1.91:
+  ctypedef uint64_t bladerf_frequency
+ELSE:
+  ctypedef unsigned int bladerf_frequency
 
 ctypedef unsigned int bladerf_sample_rate
 ctypedef unsigned int bladerf_bandwidth

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -95,8 +95,8 @@ cdef extern from "libbladeRF.h":
         int bladerf_get_bandwidth(bladerf *dev, bladerf_module module, unsigned int *bandwidth)
 
     IF BLADERF_API_VERSION >= 2:
-      int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
-      int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
+        int bladerf_set_bias_tee(bladerf *dev, bladerf_channel ch, bool enable)
+        int bladerf_get_bias_tee(bladerf *dev, bladerf_channel ch, bool *enable)
 
     IF BLADERF_API_VERSION >= 1.91:
         int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, uint64_t frequency)

--- a/src/urh/dev/native/lib/cbladerf.pxd
+++ b/src/urh/dev/native/lib/cbladerf.pxd
@@ -1,6 +1,11 @@
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 from libcpp cimport bool
 
+IF BLADERF_API_VERSION >= 1.91:
+    ctypedef uint64_t bladerf_frequency
+ELSE:
+    ctypedef unsigned int bladerf_frequency
+    
 cdef extern from "libbladeRF.h":
     struct bladerf
 
@@ -94,9 +99,6 @@ cdef extern from "libbladeRF.h":
         int bladerf_set_bandwidth(bladerf *dev, bladerf_module module, unsigned int bandwidth, unsigned int *actual)
         int bladerf_get_bandwidth(bladerf *dev, bladerf_module module, unsigned int *bandwidth)
 
-    IF BLADERF_API_VERSION >= 2:
-        int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, bladerf_frequency frequency)
-        int bladerf_get_frequency(bladerf *dev, bladerf_channel ch, bladerf_frequency *frequency)
     IF BLADERF_API_VERSION >= 1.91:
         int bladerf_set_frequency(bladerf *dev, bladerf_channel ch, uint64_t frequency)
         int bladerf_get_frequency(bladerf *dev, bladerf_channel ch, uint64_t *frequency)
@@ -128,11 +130,6 @@ cdef extern from "libbladeRF.h":
 
     int bladerf_sync_rx(bladerf *dev, void *samples, unsigned int num_samples, bladerf_metadata *metadata, unsigned int timeout_ms)
     int bladerf_sync_tx(bladerf *dev, const void *samples, unsigned int num_samples, bladerf_metadata *metadata, unsigned int timeout_ms)
-
-IF BLADERF_API_VERSION >= 2:
-    ctypedef uint64_t bladerf_frequency
-ELSE:
-    ctypedef unsigned int bladerf_frequency
 
 ctypedef unsigned int bladerf_sample_rate
 ctypedef unsigned int bladerf_bandwidth


### PR DESCRIPTION
This tool is insanely amazing =) congrats on all the effort to pull all this off like a pro. 

This PR implements a feature that is was requested way back (#703) however, sadly at my lab I only have bladeRF v1 generation. The implementation should work setting up both bias tee on rx and tx side. 

Being said that, @jopohl there is any chance that you could have both bias tee module to test this locally at your lab? 

fix #703 


 