### PR TITLE
Signal: retain the sample_rate on create_new

### DIFF
--- a/src/urh/signalprocessing/Signal.py
+++ b/src/urh/signalprocessing/Signal.py
@@ -410,6 +410,7 @@ class Signal(QObject):
         new_signal.wav_mode = self.wav_mode
         new_signal.__already_demodulated = self.__already_demodulated
         new_signal.changed = True
+        new_signal.sample_rate = self.sample_rate
         return new_signal
 
     def get_thresholds_for_center(self, center: float, spacing=None):


### PR DESCRIPTION
When using "Create signal from selection" feature, the newly created
signal does not retain sample rate of the original so all the time of
the selection is computed wrong which is very confusing to the user.

This simple patch makes sure the sample_rate of the original Signal is
copied to the newly created one which fixes the problem.