### PR TITLE
remove HackRF anti-freeze timeouts in places that do not require them

### DIFF
--- a/src/urh/dev/native/lib/hackrf.pyx
+++ b/src/urh/dev/native/lib/hackrf.pyx
@@ -113,7 +113,6 @@ cpdef int stop_tx_mode():
     return chackrf.hackrf_stop_tx(_c_device)
 
 cpdef int set_freq(freq_hz):
-    time.sleep(TIMEOUT)
     return chackrf.hackrf_set_freq(_c_device, freq_hz)
 
 cpdef is_streaming():
@@ -125,7 +124,6 @@ cpdef is_streaming():
         return False
 
 cpdef int set_amp_enable(value):
-    time.sleep(TIMEOUT)
     cdef uint8_t val = 1 if value else 0
     return chackrf.hackrf_set_amp_enable(_c_device, val)
 
@@ -135,28 +133,22 @@ cpdef int set_rf_gain(value):
 
 cpdef int set_if_rx_gain(value):
     """ Sets the LNA gain, in 8Db steps, maximum value of 40 """
-    time.sleep(TIMEOUT)
     return chackrf.hackrf_set_lna_gain(_c_device, value)
 
 cpdef int set_if_tx_gain(value):
     """ Sets the txvga gain, in 1db steps, maximum value of 47 """
-    time.sleep(TIMEOUT)
     return chackrf.hackrf_set_txvga_gain(_c_device, value)
 
 cpdef int set_baseband_gain(value):
     """ Sets the vga gain, in 2db steps, maximum value of 62 """
-    time.sleep(TIMEOUT)
     return chackrf.hackrf_set_vga_gain(_c_device, value)
 
 cpdef int set_sample_rate(sample_rate):
-    time.sleep(TIMEOUT)
     return chackrf.hackrf_set_sample_rate(_c_device, sample_rate)
 
 cpdef int set_bias_tee(on_or_off):
-    time.sleep(TIMEOUT)
     cdef uint8_t bias_tee = 1 if on_or_off else 0
     return chackrf.hackrf_set_antenna_enable(_c_device, bias_tee)
 
 cpdef int set_baseband_filter_bandwidth(bandwidth_hz):
-    time.sleep(TIMEOUT)
     return chackrf.hackrf_set_baseband_filter_bandwidth(_c_device, bandwidth_hz)


### PR DESCRIPTION
The HackRF device has a freeze-bug when stopping sending or receiving data. As a workaround, there is a 0.2 second timeout in hackrf.pyx.

As far as I can tell, this timeout is only required in `stop_rx_mode` and `stop_tx_mode`. The additional timeouts in the `set_*` methods are an issue because they cause a combined delay of one complete second whenever something is supposed to be sent (e. g. using cli).

I have been running the following code without issues for a while in an application, that sends some data every couple of minutes.
~~~~
        hackrf.TIMEOUT = 0
        hackrf.set_freq(self.args.frequency)
        hackrf.set_sample_rate(self.args.sample_rate)
        hackrf.set_baseband_filter_bandwidth(bandwidth)
        hackrf.set_rf_gain(gain)
        hackrf.set_if_tx_gain(if_gain)
        hackrf.TIMEOUT = 0.2
~~~~

I did some manual testing in the urh gui, too.