### PR TITLE
MacOS: Add default include dir during installation

### DIFF
--- a/src/urh/dev/native/ExtensionHelper.py
+++ b/src/urh/dev/native/ExtensionHelper.py
@@ -138,7 +138,6 @@ def get_device_extensions_and_extras(library_dirs=None, include_dirs=None):
         if os.path.isdir("/opt/local/include"):
             include_dirs.append("/opt/local/include")
 
-    print("INCLUDE_DIRS", include_dirs)
     result = []
 
     # None = automatic (depending on lib is installed)

--- a/src/urh/dev/native/ExtensionHelper.py
+++ b/src/urh/dev/native/ExtensionHelper.py
@@ -130,12 +130,15 @@ def get_device_extensions_and_extras(library_dirs=None, include_dirs=None):
     if sys.platform == "darwin":
         # On Mac OS X clang is by default not smart enough to search in the lib dir
         # see: https://github.com/jopohl/urh/issues/173
+        library_dirs.append("/usr/local/lib")
+        include_dirs.append("/usr/local/include")
+
         if os.path.isdir("/opt/local/lib"):
             library_dirs.append("/opt/local/lib")
-        library_dirs.append("/usr/local/lib")
         if os.path.isdir("/opt/local/include"):
             include_dirs.append("/opt/local/include")
 
+    print("INCLUDE_DIRS", include_dirs)
     result = []
 
     # None = automatic (depending on lib is installed)


### PR DESCRIPTION
fix #936