### PR TITLE
Feature/signal real timestamp

### DIFF
--- a/src/urh/controller/MainController.py
+++ b/src/urh/controller/MainController.py
@@ -391,7 +391,9 @@ class MainController(QMainWindow):
         self.ui.tabWidget.setCurrentIndex(3)
         self.simulator_tab_controller.load_simulator_file(filename)
 
-    def add_signalfile(self, filename: str, group_id=0, enforce_sample_rate=None):
+    def add_signalfile(
+        self, filename: str, group_id=0, enforce_sample_rate=None, signal_timestamp=0
+    ):
         if not os.path.exists(filename):
             QMessageBox.critical(
                 self,
@@ -411,7 +413,9 @@ class MainController(QMainWindow):
         else:
             sample_rate = self.project_manager.device_conf["sample_rate"]
 
-        signal = Signal(filename, sig_name, sample_rate=sample_rate)
+        signal = Signal(
+            filename, sig_name, sample_rate=sample_rate, timestamp=signal_timestamp
+        )
 
         self.file_proxy_model.open_files.add(filename)
         self.add_signal(signal, group_id)
@@ -944,11 +948,15 @@ class MainController(QMainWindow):
         r.device_parameters_changed.connect(pm.set_device_parameters)
         r.show()
 
-    @pyqtSlot(list, float)
-    def on_signals_recorded(self, file_names: list, sample_rate: float):
+    @pyqtSlot(list)
+    def on_signals_recorded(self, recorded_files: list):
         QApplication.instance().setOverrideCursor(Qt.WaitCursor)
-        for filename in file_names:
-            self.add_signalfile(filename, enforce_sample_rate=sample_rate)
+        for recorded_file in recorded_files:
+            self.add_signalfile(
+                recorded_file.filename,
+                enforce_sample_rate=recorded_file.sample_rate,
+                signal_timestamp=recorded_file.timestamp,
+            )
         QApplication.instance().restoreOverrideCursor()
 
     @pyqtSlot()

--- a/src/urh/controller/dialogs/ReceiveDialog.py
+++ b/src/urh/controller/dialogs/ReceiveDialog.py
@@ -9,10 +9,11 @@ from urh.ui.painting.LiveSceneManager import LiveSceneManager
 from urh.util import FileOperator
 from urh.util.Formatter import Formatter
 from datetime import datetime
+from urh.signalprocessing.RecordedFile import RecordedFile
 
 
 class ReceiveDialog(SendRecvDialog):
-    files_recorded = pyqtSignal(list, float)
+    files_recorded = pyqtSignal(list)
 
     def __init__(self, project_manager, parent=None, testing_mode=False):
         try:
@@ -53,12 +54,7 @@ class ReceiveDialog(SendRecvDialog):
             elif reply == QMessageBox.Abort:
                 return False
 
-        try:
-            sample_rate = self.device.sample_rate
-        except:
-            sample_rate = 1e6
-
-        self.files_recorded.emit(self.recorded_files, sample_rate)
+        self.files_recorded.emit(self.recorded_files)
         return True
 
     def update_view(self):
@@ -109,9 +105,11 @@ class ReceiveDialog(SendRecvDialog):
 
         dev = self.device
         big_val = Formatter.big_value_with_suffix
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp_str = datetime.fromtimestamp(dev.data_timestamp).strftime(
+            "%Y%m%d_%H%M%S"
+        )
         initial_name = "{0}-{1}-{2}Hz-{3}Sps".format(
-            dev.name, timestamp, big_val(dev.frequency), big_val(dev.sample_rate)
+            dev.name, timestamp_str, big_val(dev.frequency), big_val(dev.sample_rate)
         )
 
         if dev.bandwidth_is_adjustable:
@@ -125,5 +123,9 @@ class ReceiveDialog(SendRecvDialog):
             initial_name, data, sample_rate=dev.sample_rate, parent=self
         )
         self.already_saved = True
-        if filename is not None and filename not in self.recorded_files:
-            self.recorded_files.append(filename)
+        if filename is not None and filename not in (
+            x.filename for x in self.recorded_files
+        ):
+            self.recorded_files.append(
+                RecordedFile(filename, dev.sample_rate, dev.data_timestamp)
+            )

--- a/src/urh/controller/dialogs/SendRecvDialog.py
+++ b/src/urh/controller/dialogs/SendRecvDialog.py
@@ -157,6 +157,7 @@ class SendRecvDialog(QDialog):
     def reset(self):
         self.device.current_index = 0
         self.device.current_iteration = 0
+        self.device.reset_data_timestamp()
         self.ui.lSamplesCaptured.setText("0")
         self.ui.lSignalSize.setText("0")
         self.ui.lTime.setText("0")

--- a/src/urh/controller/widgets/SignalFrame.py
+++ b/src/urh/controller/widgets/SignalFrame.py
@@ -1574,7 +1574,9 @@ class SignalFrame(QFrame):
             time.sleep(0.1)
 
         filtered = np.frombuffer(filtered.get_obj(), dtype=np.complex64)
-        signal = self.signal.create_new(new_data=filtered.astype(np.complex64))
+        signal = self.signal.create_new(
+            new_data=filtered.astype(np.complex64), new_timestamp=self.signal.timestamp
+        )
         signal.name = (
             self.signal.name
             + " filtered with f_low={0:.4n} f_high={1:.4n} bw={2:.4n}".format(

--- a/src/urh/dev/VirtualDevice.py
+++ b/src/urh/dev/VirtualDevice.py
@@ -60,6 +60,7 @@ class VirtualDevice(QObject):
         self.name = name
         self.mode = mode
         self.backend_handler = backend_handler
+        self.__data_timestamp = 0
 
         freq = config.DEFAULT_FREQUENCY if freq is None else freq
         sample_rate = config.DEFAULT_SAMPLE_RATE if sample_rate is None else sample_rate
@@ -493,7 +494,10 @@ class VirtualDevice(QObject):
 
     @property
     def sample_rate(self):
-        return self.__dev.sample_rate
+        try:
+            return self.__dev.sample_rate
+        except:
+            return 1e6
 
     @sample_rate.setter
     def sample_rate(self, value):
@@ -631,6 +635,23 @@ class VirtualDevice(QObject):
                 "{}:{} has no data".format(self.__class__.__name__, self.backend.name)
             )
 
+    @property
+    def data_timestamp(self):
+        if self.backend == Backends.native:
+            try:
+                self.__data_timestamp = (
+                    self.__dev.first_data_timestamp
+                )  # more accurate timestamp
+            except:
+                pass
+        return self.__data_timestamp
+
+    def reset_data_timestamp(self):
+        if self.backend == Backends.native:
+            self.__dev.reset_first_data_timestamp()
+        else:
+            self.__data_timestamp = time.time()
+
     def free_data(self):
         if self.backend == Backends.grc:
             self.__dev.data = None
@@ -740,6 +761,7 @@ class VirtualDevice(QObject):
             raise ValueError("Spectrum x only available in spectrum mode")
 
     def start(self):
+        self.__data_timestamp = time.time()
         if self.backend == Backends.grc:
             self.__dev.setTerminationEnabled(True)
             self.__dev.terminate()

--- a/src/urh/dev/native/Device.py
+++ b/src/urh/dev/native/Device.py
@@ -304,6 +304,7 @@ class Device(object):
         self.error_codes = {}
         self.device_messages = []
 
+        self.__first_data_timestamp = 0
         self.receive_process_function = self.device_receive
         self.send_process_function = self.device_send
 
@@ -654,7 +655,15 @@ class Device(object):
         except (BrokenPipeError, OSError):
             pass
 
+    @property
+    def first_data_timestamp(self):
+        return self.__first_data_timestamp
+
+    def reset_first_data_timestamp(self):
+        self.__first_data_timestamp = 0
+
     def start_rx_mode(self):
+        self.__first_data_timestamp = 0
         self.init_recv_buffer()
         self.parent_data_conn, self.child_data_conn = Pipe(duplex=False)
         self.parent_ctrl_conn, self.child_ctrl_conn = Pipe()
@@ -783,8 +792,20 @@ class Device(object):
         while self.is_receiving:
             try:
                 byte_buffer = self.parent_data_conn.recv_bytes()
+
+                if self.__first_data_timestamp == 0:
+                    self.__first_data_timestamp = time.time()
+                    calculating_timestamp = True
+                else:
+                    calculating_timestamp = False
+
                 samples = self.bytes_to_iq(byte_buffer)
                 n_samples = len(samples)
+
+                if calculating_timestamp:
+                    # Timestamp accurate correction
+                    self.__first_data_timestamp -= n_samples / self.sample_rate
+
                 if n_samples == 0:
                     continue
 

--- a/src/urh/signalprocessing/Message.py
+++ b/src/urh/signalprocessing/Message.py
@@ -56,6 +56,7 @@ class Message(object):
         samples_per_symbol=100,
         participant=None,
         bits_per_symbol=1,
+        timestamp=0,
     ):
         """
 
@@ -75,7 +76,12 @@ class Message(object):
         self.participant = participant  # type: Participant
         self.message_type = message_type  # type: MessageType
 
-        self.timestamp = time.time()
+        if timestamp == 0:
+            self.timestamp = time.time()
+        else:
+            # Caller passed specific timestamp for this message
+            self.timestamp = timestamp
+
         self.absolute_time = 0  # set in Compare Frame
         self.relative_time = 0  # set in Compare Frame
 

--- a/src/urh/signalprocessing/ProtocolAnalyzer.py
+++ b/src/urh/signalprocessing/ProtocolAnalyzer.py
@@ -267,6 +267,9 @@ class ProtocolAnalyzer(object):
             middle_bit_pos = bit_sample_pos[i][int(len(bits) / 2)]
             start, end = middle_bit_pos, middle_bit_pos + samples_per_symbol
             rssi = np.mean(signal.iq_array.subarray(start, end).magnitudes_normalized)
+            message_timestamp = signal.timestamp + (
+                bit_sample_pos[i][0] / signal.sample_rate
+            )
             message = Message(
                 bits,
                 pause,
@@ -276,6 +279,7 @@ class ProtocolAnalyzer(object):
                 decoder=self.decoder,
                 bit_sample_pos=bit_sample_pos[i],
                 bits_per_symbol=signal.bits_per_symbol,
+                timestamp=message_timestamp,
             )
             self.messages.append(message)
             i += 1

--- a/src/urh/signalprocessing/ProtocolSniffer.py
+++ b/src/urh/signalprocessing/ProtocolSniffer.py
@@ -236,6 +236,9 @@ class ProtocolSniffer(ProtocolAnalyzer, QObject):
 
         # clear cache and start a new message
         self.signal.iq_array = IQArray(self.__buffer[0 : self.__current_buffer_index])
+        self.signal.timestamp = time.time() - (
+            len(self.signal.iq_array) / self.rcv_device.sample_rate
+        )  # timestamp of the first sample in our buffer
         self.__clear_buffer()
         self.signal._qad = None
 
@@ -259,19 +262,25 @@ class ProtocolSniffer(ProtocolAnalyzer, QObject):
             ppseq,
             samples_per_symbol,
             self.signal.bits_per_symbol,
-            write_bit_sample_pos=False,
+            write_bit_sample_pos=True,
         )
 
+        i = 0
         for bits, pause in zip(bit_data, pauses):
+            message_timestamp = self.signal.timestamp + (
+                bit_sample_pos[i][0] / self.rcv_device.sample_rate
+            )
             message = Message(
                 bits,
                 pause,
                 samples_per_symbol=samples_per_symbol,
                 message_type=self.default_message_type,
                 decoder=self.decoder,
+                timestamp=message_timestamp,
             )
             self.messages.append(message)
             self.message_sniffed.emit(len(self.messages) - 1)
+            i += 1
 
     def stop(self):
         self.is_running = False

--- a/src/urh/signalprocessing/RecordedFile.py
+++ b/src/urh/signalprocessing/RecordedFile.py
@@ -1,0 +1,5 @@
+class RecordedFile:
+    def __init__(self, filename, sample_rate, timestamp):
+        self.filename = filename
+        self.sample_rate = sample_rate
+        self.timestamp = timestamp

--- a/src/urh/signalprocessing/Signal.py
+++ b/src/urh/signalprocessing/Signal.py
@@ -505,13 +505,15 @@ class Signal(QObject):
             )
             return self.noise_threshold_relative
 
-    def create_new(self, start=0, end=0, new_data=None):
+    def create_new(self, start=0, end=0, new_data=None, new_timestamp=0):
         new_signal = Signal("", "New " + self.name)
 
         if new_data is None:
             new_signal.iq_array = IQArray(self.iq_array[start:end])
+            new_signal.__timestamp = self.timestamp + (start / self.sample_rate)
         else:
             new_signal.iq_array = IQArray(new_data)
+            new_signal.__timestamp = new_timestamp
 
         new_signal._noise_threshold = self.noise_threshold
         new_signal.noise_min_plot = self.noise_min_plot

--- a/src/urh/signalprocessing/Signal.py
+++ b/src/urh/signalprocessing/Signal.py
@@ -45,6 +45,7 @@ class Signal(QObject):
         name="Signal",
         modulation: str = None,
         sample_rate: float = 1e6,
+        timestamp: float = 0,
         parent=None,
     ):
         super().__init__(parent)
@@ -58,6 +59,7 @@ class Signal(QObject):
         self.__center = 0
         self._noise_threshold = 0
         self.__sample_rate = sample_rate
+        self.__timestamp = timestamp
         self.noise_min_plot = 0
         self.noise_max_plot = 0
         self.block_protocol_update = False
@@ -224,6 +226,10 @@ class Signal(QObject):
             self.__sample_rate = val
             self.sample_rate_changed.emit(val)
 
+    @property
+    def timestamp(self):
+        return self.__timestamp
+    
     @property
     def parameter_cache(self) -> dict:
         """

--- a/src/urh/signalprocessing/Signal.py
+++ b/src/urh/signalprocessing/Signal.py
@@ -229,7 +229,11 @@ class Signal(QObject):
     @property
     def timestamp(self):
         return self.__timestamp
-    
+
+    @timestamp.setter
+    def timestamp(self, val):
+        self.__timestamp = val
+
     @property
     def parameter_cache(self) -> dict:
         """


### PR DESCRIPTION
Adding timestamps to Recorded Signals and ProtocolAnalyzer messages
Adding timestamps to messages generated in ProtocolSniffer

Before this PR, signals and messages interpreted by protocol analyzer, had no real timestamps; just some relative time measurements between each messages in signal. Now timestamps are absolute and are saved into proto.xml files correctly for future reference.