### PR TITLE
Add paths for homebrew on M1 Mac / Apple Silicon

### DIFF
--- a/src/urh/dev/native/ExtensionHelper.py
+++ b/src/urh/dev/native/ExtensionHelper.py
@@ -115,8 +115,9 @@ def get_device_extensions_and_extras(library_dirs=None, include_dirs=None):
         library_dirs.insert(0, os.path.realpath(os.path.join(cur_dir, "lib/shared")))
 
     if sys.platform == "darwin":
-        include_dirs.append("/usr/local/include")
-        library_dirs.append("/usr/local/lib")
+        for prefix in ["/usr/local", "/opt/homebrew"]:
+            include_dirs.append(prefix + "/include")
+            library_dirs.append(prefix + "/lib")
 
     result = []
 


### PR DESCRIPTION
This adds the relevant paths to pick up e.g. `rtlsdr` installed via arm64
homebrew on an M1 Mac. Without this patch fails to pick up rtlsdr, with this
patch finds the relevant devices.

See also: https://github.com/jopohl/urh/issues/173
