### PR TITLE
'Remove Carrier' encoding truncates initial input

### DIFF
--- a/src/urh/signalprocessing/Encoding.py
+++ b/src/urh/signalprocessing/Encoding.py
@@ -427,19 +427,20 @@ class Encoding(object):
             # Add carrier if encoding
             if len(self.carrier) > 0:
                 x = 0
-                while self.carrier[x % len(self.carrier)] in ("0", "1", "*"):
-                    output.append(False if self.carrier[x % len(self.carrier)] in (
-                    "0", "*") else True)  # Add 0 when there is a wildcard (*) in carrier description
-                    x += 1
                 for i in inpt:
-                    tmp = self.carrier[x % len(self.carrier)]
-                    if not tmp in ("0", "1", "*"):
-                        output.append(i)
-                        x += 1
                     while self.carrier[x % len(self.carrier)] in ("0", "1", "*"):
                         output.append(False if self.carrier[x % len(self.carrier)] in (
                         "0", "*") else True)  # Add 0 when there is a wildcard (*) in carrier description
                         x += 1
+                    tmp = self.carrier[x % len(self.carrier)]
+                    if not tmp in ("0", "1", "*"):
+                        output.append(i)
+                        x += 1
+                # Consume the trailing carrier pattern avoiding any wrap around
+                while x % len(self.carrier) > 0 and self.carrier[x % len(self.carrier)] in ("0", "1", "*"):
+                    output.append(False if self.carrier[x % len(self.carrier)] in (
+                    "0", "*") else True)  # Add 0 when there is a wildcard (*) in carrier description
+                    x += 1
         return output, errors, self.ErrorState.SUCCESS
 
     def code_data_whitening(self, decoding, inpt):

--- a/src/urh/signalprocessing/Encoding.py
+++ b/src/urh/signalprocessing/Encoding.py
@@ -427,6 +427,10 @@ class Encoding(object):
             # Add carrier if encoding
             if len(self.carrier) > 0:
                 x = 0
+                while self.carrier[x % len(self.carrier)] in ("0", "1", "*"):
+                    output.append(False if self.carrier[x % len(self.carrier)] in (
+                    "0", "*") else True)  # Add 0 when there is a wildcard (*) in carrier description
+                    x += 1
                 for i in inpt:
                     tmp = self.carrier[x % len(self.carrier)]
                     if not tmp in ("0", "1", "*"):


### PR DESCRIPTION
Hi,
I had an issue while trying to fuzz a remote control switch, despite successful decoding.

#### The issue
Basically, the raw signal gets perfectly decoded by a 'Remove Carrier' function with a `0_0_0_0_0_0_0_0_0_0_0_0_0` pattern. (12 data symbols interleaved with 0s)

However, the inverse function truncates the very first `0_` pair, whatever the value of the input data.
This happens if the very first character does not represent input data, as the code does not enter the `if` statement.
This makes the `for` loop skip the first input sequence altogether.

#### The proposed fix
I managed to solve this problem by inverting the two actions within the `for` loop (i.e. consume the carrier *first*).
Once all the input is consumed, the remaining carrier pattern is appended until it wraps around.

I hope you'll find this useful too!

#### Commit 8fbab14
Addresses truncation by consuming any leading carrier symbol before the `for` loop.

#### Commit 523a1d9
Addresses an issue with 8fbab14 where extra carrier symbols get included, due to the pattern wrapping around after all input data has been consumed.