### PR TITLE
Flipper raw

### DIFF
--- a/src/urh/controller/widgets/SignalFrame.py
+++ b/src/urh/controller/widgets/SignalFrame.py
@@ -466,7 +466,7 @@ class SignalFrame(QFrame):
             try:
                 self.setCursor(Qt.WaitCursor)
                 data = self.signal.qad
-                if filename.endswith(".wav"):
+                if filename.endswith(".wav") or filename.endswith(".sub"):
                     data = self.signal.qad.astype(np.float32)
                     data /= np.max(np.abs(data))
                 FileOperator.save_data(IQArray(data, skip_conversion=True), filename, self.signal.sample_rate,

--- a/src/urh/signalprocessing/IQArray.py
+++ b/src/urh/signalprocessing/IQArray.py
@@ -249,10 +249,7 @@ class IQArray(object):
         for value in self.convert_to(np.uint8):
             # if origin was a sub-file value is uint8, else value is [uint8, uint8]
             # TODO: export only works with sub files. Idea: Export from bit stream?
-            try:
-                value = np.linalg.norm(value)
-            except:
-                pass
+            value = np.linalg.norm(value)
 
             # set lastvalue to value for first run
             try:

--- a/src/urh/signalprocessing/Signal.py
+++ b/src/urh/signalprocessing/Signal.py
@@ -443,6 +443,7 @@ class Signal(QObject):
         new_signal.__bits_per_symbol = self.bits_per_symbol
         new_signal.__center = self.center
         new_signal.wav_mode = self.wav_mode
+        new_signal.flipper_raw_mode = self.flipper_raw_mode
         new_signal.__already_demodulated = self.__already_demodulated
         new_signal.changed = True
         new_signal.sample_rate = self.sample_rate

--- a/src/urh/util/FileOperator.py
+++ b/src/urh/util/FileOperator.py
@@ -95,7 +95,6 @@ def ask_save_file_name(initial_name: str, caption="Save signal", selected_name_f
     elif caption == "Save protocol":
         name_filter = ";;".join([PROTOCOL_FILE_FILTER, BINARY_PROTOCOL_FILE_FILTER])
     elif caption == "Export demodulated":
-        #name_filter = WAV_FILE_FILTER
         name_filter = ";;".join([WAV_FILE_FILTER, SUB_FILE_FILTER])
     else:
         name_filter = EVERYTHING_FILE_FILTER

--- a/src/urh/util/FileOperator.py
+++ b/src/urh/util/FileOperator.py
@@ -47,7 +47,7 @@ FUZZING_FILE_FILTER = "Fuzzing Profile (*.fuzz.xml *.fuzz)"
 SIMULATOR_FILE_FILTER = "Simulator Profile (*.sim.xml *.sim)"
 TAR_FILE_FILTER = "Tar Archive (*.tar *.tar.gz *.tar.bz2)"
 ZIP_FILE_FILTER = "Zip Archive (*.zip)"
-
+SUB_FILE_FILTER = "Flipper SubGHz RAW (*.sub)"
 
 def __get__name_filter_for_signals() -> str:
     return ";;".join([EVERYTHING_FILE_FILTER] + SIGNAL_NAME_FILTERS + [COMPRESSED_COMPLEX_FILE_FILTER, WAV_FILE_FILTER])
@@ -95,7 +95,8 @@ def ask_save_file_name(initial_name: str, caption="Save signal", selected_name_f
     elif caption == "Save protocol":
         name_filter = ";;".join([PROTOCOL_FILE_FILTER, BINARY_PROTOCOL_FILE_FILTER])
     elif caption == "Export demodulated":
-        name_filter = WAV_FILE_FILTER
+        #name_filter = WAV_FILE_FILTER
+        name_filter = ";;".join([WAV_FILE_FILTER, SUB_FILE_FILTER])
     else:
         name_filter = EVERYTHING_FILE_FILTER
 
@@ -157,6 +158,8 @@ def save_data(data, filename: str, sample_rate=1e6, num_channels=2):
         data.export_to_wav(filename, num_channels, sample_rate)
     elif filename.endswith(".coco"):
         data.save_compressed(filename)
+    elif filename.endswith(".sub"):
+        data.export_to_sub(filename, 433920000, "FuriHalSubGhzPresetOok650Async")
     else:
         data.tofile(filename)
 


### PR DESCRIPTION
Add support for Flipper Zero .sub files
- Read
- Write (only if the source was a .sub file and with constant parameters)

Future work: Implement export to .sub files in Generator as a plugin (similar to YardStick that also uses CC1101) to support different parameters.