### PR TITLE
    For a long time, np.int has been an alias of the builtin int. Thi…

### DIFF
--- a/src/urh/signalprocessing/Filter.py
+++ b/src/urh/signalprocessing/Filter.py
@@ -123,4 +123,4 @@ class Filter(object):
 
         # https://dsp.stackexchange.com/questions/41361/how-to-implement-bandpass-filter-on-complex-valued-signal
         return Filter.design_windowed_sinc_lpf(f_c, bw=bw) * \
-               np.exp(np.complex(0, 1) * np.pi * 2 * f_shift * np.arange(0, N, dtype=complex))
+               np.exp(complex(0, 1) * np.pi * 2 * f_shift * np.arange(0, N, dtype=complex))

--- a/src/urh/signalprocessing/Spectrogram.py
+++ b/src/urh/signalprocessing/Spectrogram.py
@@ -169,7 +169,7 @@ class Spectrogram(object):
         else:
             normalized_values = data.T
 
-        return np.take(colormap, normalized_values.astype(np.int), axis=0, mode='clip')
+        return np.take(colormap, normalized_values.astype(int), axis=0, mode='clip')
 
     @staticmethod
     def create_image(data: np.ndarray, colormap, data_min=None, data_max=None, normalize=True) -> QImage:


### PR DESCRIPTION
…s is repeatedly a cause of confusion for newcomers, and existed mainly for historic reasons.

    These aliases have been deprecated. The table below shows the full list of deprecated aliases, along with their exact meaning. Replacing uses of items in the first column with the contents of the second column will work identically and silence the deprecation warning.

    — numpy 1.20 release notes

https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated