### PR TITLE
Fix Interpretation -> Spectrogram

### DIFF
--- a/src/urh/signalprocessing/Filter.py
+++ b/src/urh/signalprocessing/Filter.py
@@ -123,4 +123,4 @@ class Filter(object):
 
         # https://dsp.stackexchange.com/questions/41361/how-to-implement-bandpass-filter-on-complex-valued-signal
         return Filter.design_windowed_sinc_lpf(f_c, bw=bw) * \
-               np.exp(np.complex(0, 1) * np.pi * 2 * f_shift * np.arange(0, N, dtype=complex))
+               np.exp(0+1j * np.pi * 2 * f_shift * np.arange(0, N, dtype=complex))

--- a/src/urh/signalprocessing/Spectrogram.py
+++ b/src/urh/signalprocessing/Spectrogram.py
@@ -169,7 +169,7 @@ class Spectrogram(object):
         else:
             normalized_values = data.T
 
-        return np.take(colormap, normalized_values.astype(np.int), axis=0, mode='clip')
+        return np.take(colormap, normalized_values.astype(np.int_), axis=0, mode='clip')
 
     @staticmethod
     def create_image(data: np.ndarray, colormap, data_min=None, data_max=None, normalize=True) -> QImage:


### PR DESCRIPTION
This change fixes:
- opening the spectrogram
- applying a band pass filter to the spectrogram to create a new signal

Crashes related to these fixes were observed on the latest release (v2.9.3) and on the master branch.

As these are very isolated fixes "to make it work", there might be an underlying issue as to _why_ they appeared in the first place. I can only speculate about the root cause (maybe pinning versions of dependencies could help), but I'll leave a more in-depth analysis to the experts.

Cheers, I hope this helps.