### PR TITLE
CI: Install PyAudio directly via pip instead of pipwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,7 @@ jobs:
             pip install PyVirtualDisplay==0.2.5
           elif [[ $OS == windows* ]]
           then
-            pip install pywin32 pipwin
-            pipwin install pyaudio
+            pip install pywin32 pyaudio
           elif [[ $OS == mac* ]] 
           then
             brew tap pothosware/homebrew-pothos


### PR DESCRIPTION
PyAudio wheels for Windows are now provided on PyPi so we do not need to use pipwin anymore.