### PR TITLE
Fix error when selecting large ranges in Interpretation

### DIFF
--- a/src/urh/signalprocessing/IQArray.py
+++ b/src/urh/signalprocessing/IQArray.py
@@ -96,7 +96,7 @@ class IQArray(object):
         return self.__data.tostring()
 
     def subarray(self, start=None, stop=None, step=None):
-        return IQArray(self[start:stop:step])
+        return IQArray(np.ascontiguousarray(self[start:stop:step]))
 
     def insert_subarray(self, pos, subarray: np.ndarray):
         if subarray.ndim == 1:


### PR DESCRIPTION
Fix errors like this:
```
[ERROR::SignalFrame.py::update_number_selected_samples] ndarray is not C-contiguous
Traceback (most recent call last):
  File "/home/andy/work/repository/urh/src/urh/controller/widgets/SignalFrame.py", line 320, in update_number_selected_samples
    power = np.mean(self.signal.iq_array.subarray(start, end, step_size).magnitudes_normalized)
  File "/home/andy/work/repository/urh/src/urh/signalprocessing/IQArray.py", line 86, in magnitudes_normalized
    return self.magnitudes / np.sqrt(self.maximum**2.0 + self.minimum**2.0)
  File "/home/andy/work/repository/urh/src/urh/signalprocessing/IQArray.py", line 82, in magnitudes
    return get_magnitudes(self.__data)
  File "src/urh/cythonext/util.pyx", line 128, in urh.cythonext.util.__pyx_fuse_0get_magnitudes
  File "stringsource", line 660, in View.MemoryView.memoryview_cwrapper
  File "stringsource", line 350, in View.MemoryView.memoryview.__cinit__
ValueError: ndarray is not C-contiguous
```
when selecting larger ranges of a Signal in Intepretation.