### PR TITLE
pin to Cython version <3.0.0

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 pyqt5
 psutil
-cython!=0.29.18
+cython<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def read_long_description():
         return ""
 
 
-install_requires = ["numpy", "psutil", "cython"]
+install_requires = ["numpy", "psutil", "cython<3.0.0"]
 if IS_RELEASE:
     install_requires.append("pyqt5")
 else:


### PR DESCRIPTION
Temporary measurement to bring the CI back to life. In perspective, we should make the Cython files compatible with version 3.0+.