### PR TITLE
Update LICENSE and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
                          dist/Universal.Radio.Hacker-"$(python src/urh/version.py)".dmg
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.os }}
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}-${{ matrix.python_version }}-${{ matrix.architecture }}
+          name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.architecture }}
           path: dist
 
       - name: Run pytest with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}
+          name: dist-${{ matrix.os }}-${{ matrix.python_version }}-${{ matrix.architecture }}
           path: dist
 
       - name: Run pytest with coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         architecture: [x64]
         include:
-          - os: windows-2019
+          - os: windows-latest
             python-version: '3.11'
             architecture: x86
         exclude:
-          - os: windows-2019
+          - os: windows-latest
             python-version: '3.8'
-          - os: windows-2019
+          - os: windows-latest
             python-version: '3.9'
-          - os: windows-2019
+          - os: windows-latest
             python-version: '3.10'
-          - os: windows-2019
+          - os: windows-latest
             python-version: '3.12'
           - os: macOS-12
             python-version: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-12]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         architecture: [x64]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
         architecture: [x64]
         include:
           - os: windows-2019
-            python-version: '3.8'
+            python-version: '3.11'
             architecture: x86
         exclude:
+          - os: windows-2019
+            python-version: '3.8'
           - os: windows-2019
             python-version: '3.9'
           - os: windows-2019
             python-version: '3.10'
-          - os: windows-2019
-            python-version: '3.11'
           - os: windows-2019
             python-version: '3.12'
           - os: macOS-12

--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     Universal Radio Hacker: investigate wireless protocols like a boss
-    Copyright (C) 2023 Johannes Pohl and Andreas Noack
+    Copyright (C) 2024 Johannes Pohl and Andreas Noack
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Universal Radio Hacker Copyright (C) 2023 Johannes Pohl and Andreas Noack
+    Universal Radio Hacker Copyright (C) 2024 Johannes Pohl and Andreas Noack
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
- Update License year
- Use Python 3.11 for bundled Windows builds
- Use `windows-latest` for CI