### PR TITLE
Add conftest.py to awre test dir

### DIFF
--- a/tests/awre/conftest.py
+++ b/tests/awre/conftest.py
@@ -1,0 +1,3 @@
+from urh.controller.dialogs.OptionsDialog import OptionsDialog
+
+OptionsDialog.write_default_options()


### PR DESCRIPTION
To prevent `fieldtypes.xml` not found for tests on macOS