### PR TITLE
Fixed build with python-3.13

### DIFF
--- a/src/urh/dev/native/lib/airspy.pyx
+++ b/src/urh/dev/native/lib/airspy.pyx
@@ -7,9 +7,6 @@ from cython.view cimport array as cvarray  # needed for converting of malloc arr
 from urh.util.Logger import logger
 
 
-cdef extern from "Python.h":
-    void PyEval_InitThreads()
-
 ctypedef unsigned char uint8_t
 ctypedef unsigned int uint32_t
 ctypedef unsigned long long uint64_t
@@ -81,7 +78,6 @@ cpdef int set_if_rx_gain(uint8_t vga_gain):
 cpdef int start_rx(callback):
     global f
     f = callback
-    PyEval_InitThreads()
     cairspy.airspy_set_sample_type(_c_device, cairspy.airspy_sample_type.AIRSPY_SAMPLE_FLOAT32_IQ)
     return cairspy.airspy_start_rx(_c_device, _c_callback_recv, NULL)
 


### PR DESCRIPTION
According to https://docs.python.org/3.13/whatsnew/3.13.html:

Remove PyEval_InitThreads() and PyEval_ThreadsInitialized() functions, deprecated in Python 3.9. Since Python 3.7, Py_Initialize() always creates the GIL: calling PyEval_InitThreads() did nothing and PyEval_ThreadsInitialized() always returned non-zero. (Contributed by Victor Stinner in https://github.com/python/cpython/issues/105182.)

If support for < python-3.7 is required, conditionals have to be added