### PR TITLE
Add setuptools to requirements.txt

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pyqt5
 psutil
 cython
+setuptools


### PR DESCRIPTION
Python 3.12 dropped `distutils` from the standard library so we need `setuptools` to run URH. This fixes #1113.