### PR TITLE
Requirements: Pin to numpy 1.x.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
             pip install pywin32 pyaudio
           elif [[ $OS == mac* ]] 
           then
-            brew tap pothosware/homebrew-pothos
             brew install airspy hackrf librtlsdr libbladerf limesuite portaudio uhd
             
             wget -nv https://github.com/analogdevicesinc/libiio/releases/download/v0.23/macOS-10.15.pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             pip install pywin32 pyaudio
           elif [[ $OS == mac* ]] 
           then
-            brew install airspy hackrf librtlsdr libbladerf limesuite portaudio uhd
+            brew install airspy hackrf librtlsdr libbladerf pothosware/homebrew-pothos/limesuite portaudio uhd
             
             wget -nv https://github.com/analogdevicesinc/libiio/releases/download/v0.23/macOS-10.15.pkg
             sudo installer -pkg macOS-10.15.pkg -target /

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2.0.0
 pyqt5
 psutil
 cython


### PR DESCRIPTION
As suggested [here](https://github.com/jopohl/urh/issues/1123#issuecomment-2252712620) pin the numpy version to prevent errors with pipx.

This fixes #1144 and fixes #1122.