### PR TITLE
Remove conditionals for python<3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,9 +151,6 @@ else:
     except ImportError:
         install_requires.append("pyqt5")
 
-if sys.version_info < (3, 4):
-    install_requires.append("enum34")
-
 setup(
     name="urh",
     version=version.VERSION,

--- a/src/urh/dev/gr/scripts/InputHandlerThread.py
+++ b/src/urh/dev/gr/scripts/InputHandlerThread.py
@@ -1,9 +1,6 @@
 import sys
 
-if sys.version_info[0] >= 3:
-    from queue import Queue, Empty
-else:
-    from Queue import Queue, Empty
+from queue import Queue, Empty
 
 from threading import Thread
 import time


### PR DESCRIPTION
Python under 3.4 is not supported, so the conditions have no effect.

## Reference

Mentioned in #1162
