### PR TITLE
Force Cython <3.1

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,5 +1,5 @@
 numpy<2.0.0
 pyqt5
 psutil
-cython
+cython<3.1
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ def read_long_description():
         return ""
 
 
-install_requires = ["numpy<2.0.0", "psutil", "cython", "setuptools"]
+install_requires = ["numpy<2.0.0", "psutil", "cython<3.1", "setuptools"]
 if IS_RELEASE:
     install_requires.append("pyqt5")
 else:


### PR DESCRIPTION
Cython 3.1 compilation fails.

### Reference

Mentioned in #1165
