### PR TITLE
Fix receiving data with rtl_tcp

### DIFF
--- a/src/urh/dev/native/RTLSDRTCP.py
+++ b/src/urh/dev/native/RTLSDRTCP.py
@@ -29,7 +29,7 @@ class RTLSDRTCP(Device):
         "biasTee",
     ]
 
-    DATA_TYPE = np.uint8
+    DATA_TYPE = np.int8
 
     @staticmethod
     def receive_sync(


### PR DESCRIPTION
This PR fixes #1121.

I have tested this with `rtl_tcp` and an RTL-SDR v3 dongle, plus a remote that sends unknown data on 315 MHz.

Both the recording and spectrogram look good; see screenshots.

<img width="1358" alt="correct recording" src="https://github.com/user-attachments/assets/8eecf083-98e0-4e5a-8e73-6dda78b5bf15" />
<img width="1624" alt="correct spectrogram" src="https://github.com/user-attachments/assets/1e3878f3-c579-4f75-a19b-be42151ad361" />

Data recorded with RTL-TCP mode is now saved as `.complex16s` rather than `.complex16u` and the data can now be used for analysis.