### PR TITLE
[CI] Fix broken limesuite build for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
           elif [[ $OS == mac* ]] 
           then
             # https://stackoverflow.com/a/79622211
-            export CMAKE_POLICY_VERSION_MINIMUM=3.5
-            brew install airspy hackrf librtlsdr libbladerf pothosware/homebrew-pothos/limesuite portaudio uhd
+            CMAKE_POLICY_VERSION_MINIMUM=3.5 brew install airspy hackrf librtlsdr libbladerf pothosware/homebrew-pothos/limesuite portaudio uhd
             
             wget -nv https://github.com/analogdevicesinc/libiio/releases/download/v0.23/macOS-10.15.pkg
             sudo installer -pkg macOS-10.15.pkg -target /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,7 @@ jobs:
             pip install pywin32 pyaudio
           elif [[ $OS == mac* ]] 
           then
-            # https://stackoverflow.com/a/79622211
-            CMAKE_POLICY_VERSION_MINIMUM=3.5 brew install airspy hackrf librtlsdr libbladerf pothosware/homebrew-pothos/limesuite portaudio uhd
+            brew install airspy hackrf librtlsdr libbladerf limesuite portaudio uhd
             
             wget -nv https://github.com/analogdevicesinc/libiio/releases/download/v0.23/macOS-10.15.pkg
             sudo installer -pkg macOS-10.15.pkg -target /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
             pip install pywin32 pyaudio
           elif [[ $OS == mac* ]] 
           then
+            # https://stackoverflow.com/a/79622211
+            export CMAKE_POLICY_VERSION_MINIMUM=3.5
             brew install airspy hackrf librtlsdr libbladerf pothosware/homebrew-pothos/limesuite portaudio uhd
             
             wget -nv https://github.com/analogdevicesinc/libiio/releases/download/v0.23/macOS-10.15.pkg

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,5 +1,5 @@
 numpy<2.0.0
 pyqt5
 psutil
-cython
+cython<3.1
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ def read_long_description():
         return ""
 
 
-install_requires = ["numpy<2.0.0", "psutil", "cython", "setuptools"]
+install_requires = ["numpy<2.0.0", "psutil", "cython<3.1", "setuptools"]
 if IS_RELEASE:
     install_requires.append("pyqt5")
 else:


### PR DESCRIPTION
Building Limesuite on macOS currently fails with

```
Last 15 lines from /Users/runner/Library/Logs/Homebrew/limesuite/01.cmake:
-Wno-dev
-DBUILD_TESTING=OFF
-DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk

CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Unfortunately, homebrew does not respect `CMAKE_POLICY_VERSION_MINIMUM=3.5` when set via environment variable and there seems to be no way to specify cmake flags directly with for homebrew.

Therefore, we now switch to the `limesuite` version from the default homebrew repo. However, this version is way more recent than the other one so API incompatibilities are possible. Tests are passing though, that's a good sign.