### PR TITLE
Fix setting of bias tee with rtl_tcp

### DIFF
--- a/src/urh/dev/native/RTLSDRTCP.py
+++ b/src/urh/dev/native/RTLSDRTCP.py
@@ -24,12 +24,10 @@ class RTLSDRTCP(Device):
         "rtlXtalFreq": 0x0B,
         "tunerXtalFreq": 0x0C,
         "gainByIndex": 0x0D,
-
         # At least two rtl_tcp implementations agree on the biasTee value.
         # See https://github.com/pinkavaj/rtl-sdr/blob/master/include/rtl_tcp.h#L50
         # See https://gitea.osmocom.org/sdr/rtl-sdr/src/branch/master/src/rtl_tcp.c
         "biasTee": 0x0E,
-
         # Only pinkavaj/rtl-sdr has a bandwidth constant; osmocom does not.
         # As a result, bandwidth commands will do nothing when using osmocom's rtl_tcp.
         "bandwidth": 0x40,


### PR DESCRIPTION
The bias tee value was being set to the same value as the bandwidth.  In #1067 it was reported that the bias tee value was being set to the same value as the sample rate, but the sample rate and bandwidth are usually the same.

Urh's rtl_tcp driver never previously sent a bias tee command, but rtl_tcp was receiving one because at some point, the constants for bandwidth and bias tee got changed in the rtl_tcp implementation.  It appears that Osmocom's implementation always had the bias tee command at 0x0e; see https://gitea.osmocom.org/sdr/rtl-sdr/commit/fa3a113b77b6ed2738778a52ae4f9ce4e6f18ea3 when it was added.  However, the [pinkavaj fork](https://github.com/pinkavaj/rtl-sdr) initially had the bandwidth as 0x0e and bias tee as 0x0f.  See https://github.com/pinkavaj/rtl-sdr/blob/master/include/rtl_tcp.h#L50:
```c
#if 1
    /* development branch since 2018-10-03 */
    SET_BIAS_TEE              = 0x0E,
    SET_TUNER_BANDWIDTH       = 0x40,
#else
    /* prev code - used in ExtIO - to build compatible rtl_tcp.exe */
    SET_TUNER_BANDWIDTH       = 0x0E,
    SET_BIAS_TEE              = 0x0F
#endif
```

Urh was (quite reasonably) using the previous pinkavaj values.  However, now that it appears that at least two implementations agree that the bias tee constant is 0x0e, this PR updates the rtl_tcp command constants, updates code to send a new bias tee command as 0x0e, and sends a bandwidth command at 0x40.  The Osmocom implementation will ignore the bandwidth command because it doesn't have a bandwidth command implemented.

On macOS, with `brew install librtlsdr` (i.e. the Osmocom implementation) installed, `rtl_tcp` now receives the following when starting a capture in Urh with this configuration:

<img width="588" alt="configuration" src="https://github.com/user-attachments/assets/0c6daf8f-c720-4101-834a-10e6e0ef15ca" />

```console
$ rtl_tcp
Found 1 device(s):
  0:  Realtek, RTL2838UHIDIR, SN: 00000001

Using device 0: Generic RTL2832U OEM
Found Rafael Micro R820T tuner
[R82XX] PLL not locked!
Tuned to 100000000 Hz.
listening...
Use the device argument 'rtl_tcp=127.0.0.1:1234' in OsmoSDR (gr-osmosdr) source
to receive samples in GRC and control rtl_tcp parameters (frequency, gain, ...).
client accepted! localhost 58853
set freq 433920000
set sample rate 2000000
Exact sample rate is: 2000000.052982 Hz
set freq correction 1
set direct sampling 0
Disabled direct sampling mode
set bias tee 0
set gain 25
```

When the `Enable Bias Tee` box is checked, `set bias tee 1` is received.

Fixes #1067.