### PR TITLE
fix(numpy): replace deprecated `tostring` with `tobytes`

### DIFF
--- a/src/urh/awre/Histogram.py
+++ b/src/urh/awre/Histogram.py
@@ -99,7 +99,7 @@ class Histogram(object):
         values = defaultdict(list)
         for i in self.__active_indices:
             vector = self.__vectors[i]
-            values[vector[start : start + length].tostring()].append(i)
+            values[vector[start : start + length].tobytes()].append(i)
         value = max(values, key=lambda x: len(x))
         indices = values[value]
         return self.__vectors[indices[0]][start : start + length]

--- a/src/urh/awre/engines/AddressEngine.py
+++ b/src/urh/awre/engines/AddressEngine.py
@@ -73,7 +73,7 @@ class AddressEngine(Engine):
 
     def find(self):
         addresses_by_participant = {
-            p: [addr.tostring()]
+            p: [addr.tobytes()]
             for p, addr in self.known_addresses_by_participant.items()
         }
         addresses_by_participant.update(self.find_addresses())
@@ -208,7 +208,7 @@ class AddressEngine(Engine):
             for rng in sorted(ranges, key=lambda r: r.score, reverse=True):
                 rng.field_type = (
                     "source address"
-                    if rng.value.tostring() == address
+                    if rng.value.tobytes() == address
                     else "destination address"
                 )
                 if len(result) == 0:
@@ -315,7 +315,7 @@ class AddressEngine(Engine):
 
         for participant, addresses in addresses_by_participant.items():
             if participant in self.known_addresses_by_participant:
-                address = self.known_addresses_by_participant[participant].tostring()
+                address = self.known_addresses_by_participant[participant].tobytes()
                 scored_participants_addresses[participant][address] = 9999999999
                 continue
 
@@ -323,11 +323,11 @@ class AddressEngine(Engine):
                 matching = [
                     rng
                     for rng in high_scored_ranges_by_participant[participant]
-                    if i in rng.message_indices and rng.value.tostring() in addresses
+                    if i in rng.message_indices and rng.value.tobytes() in addresses
                 ]
 
                 if len(matching) == 1:
-                    address = matching[0].value.tostring()
+                    address = matching[0].value.tobytes()
                     # only one address, so probably a destination and not a source
                     scored_participants_addresses[participant][address] *= 0.9
 
@@ -340,11 +340,11 @@ class AddressEngine(Engine):
                                 prev_participant
                             ]
                             if i - 1 in rng.message_indices
-                            and rng.value.tostring() in addresses
+                            and rng.value.tobytes() in addresses
                         ]
                         if len(prev_matching) > 1:
                             for prev_rng in filter(
-                                lambda r: r.value.tostring() == address, prev_matching
+                                lambda r: r.value.tobytes() == address, prev_matching
                             ):
                                 scored_participants_addresses[prev_participant][
                                     address
@@ -354,7 +354,7 @@ class AddressEngine(Engine):
                     # more than one address, so there must be a source address included
                     for rng in matching:
                         scored_participants_addresses[participant][
-                            rng.value.tostring()
+                            rng.value.tobytes()
                         ] += rng.score
 
         minimum_score = 0.5
@@ -531,18 +531,18 @@ class AddressEngine(Engine):
                     if addr_len is not None and len(val) != addr_len:
                         continue
                     if not p1_already_assigned and not p2_already_assigned:
-                        result[p1].add(val.tostring())
-                        result[p2].add(val.tostring())
+                        result[p1].add(val.tobytes())
+                        result[p2].add(val.tobytes())
                     elif (
                         p1_already_assigned
                         and val.tostring()
-                        != self.known_addresses_by_participant[p1].tostring()
+                        != self.known_addresses_by_participant[p1].tobytes()
                     ):
                         result[p2].add(val.tostring())
                     elif (
                         p2_already_assigned
                         and val.tostring()
-                        != self.known_addresses_by_participant[p2].tostring()
+                        != self.known_addresses_by_participant[p2].tobytes()
                     ):
                         result[p1].add(val.tostring())
         return result

--- a/src/urh/signalprocessing/IQArray.py
+++ b/src/urh/signalprocessing/IQArray.py
@@ -93,7 +93,7 @@ class IQArray(object):
         return self.convert_to(np.float32).flatten(order="C").view(np.complex64)
 
     def to_bytes(self):
-        return self.__data.tostring()
+        return self.__data.tobytes()
 
     def subarray(self, start=None, stop=None, step=None):
         return IQArray(np.ascontiguousarray(self[start:stop:step]))

--- a/tests/awre/test_generated_protocols.py
+++ b/tests/awre/test_generated_protocols.py
@@ -152,11 +152,11 @@ class TestGeneratedProtocols(AWRETestCase):
         ff.run()
 
         self.assertIn(
-            known_participant_addresses[0].tostring(),
+            known_participant_addresses[0].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
         self.assertIn(
-            known_participant_addresses[1].tostring(),
+            known_participant_addresses[1].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
 
@@ -172,11 +172,11 @@ class TestGeneratedProtocols(AWRETestCase):
         ff.run()
 
         self.assertIn(
-            known_participant_addresses[0].tostring(),
+            known_participant_addresses[0].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
         self.assertIn(
-            known_participant_addresses[1].tostring(),
+            known_participant_addresses[1].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
 
@@ -221,11 +221,11 @@ class TestGeneratedProtocols(AWRETestCase):
         self.assertEqual(len(ff.message_types), 1)
 
         self.assertIn(
-            known_participant_addresses[0].tostring(),
+            known_participant_addresses[0].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
         self.assertIn(
-            known_participant_addresses[1].tostring(),
+            known_participant_addresses[1].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
 
@@ -244,11 +244,11 @@ class TestGeneratedProtocols(AWRETestCase):
         self.assertEqual(len(ff.message_types), 1)
 
         self.assertIn(
-            known_participant_addresses[0].tostring(),
+            known_participant_addresses[0].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
         self.assertIn(
-            known_participant_addresses[1].tostring(),
+            known_participant_addresses[1].tobytes(),
             list(map(bytes, ff.known_participant_addresses.values())),
         )
 

--- a/tests/test_send_recv_dialog_gui.py
+++ b/tests/test_send_recv_dialog_gui.py
@@ -163,7 +163,7 @@ class TestSendRecvDialog(QtTestCase):
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         sock.connect(("127.0.0.1", port))
-        sock.sendall(data.tostring())
+        sock.sendall(data.tobytes())
         sock.shutdown(socket.SHUT_RDWR)
         sock.close()
 
@@ -198,7 +198,7 @@ class TestSendRecvDialog(QtTestCase):
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         sock.connect(("127.0.0.1", port))
-        sock.sendall(data.tostring())
+        sock.sendall(data.tobytes())
         sock.shutdown(socket.SHUT_RDWR)
         sock.close()
 


### PR DESCRIPTION
Deprecated since numpy 1.19.0
https://numpy.org/doc/2.1/release/1.19.0-notes.html#numpy-ndarray-tostring-is-deprecated-in-favor-of-tobytes

Deprecations mentioned in #1149