### PR TITLE
Remove outdated dependencies from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             pip install pyaudio
             pip install pillow
           fi
-          pip install twine setuptools pytest pytest-xvfb pytest-cov pytest-faulthandler six appdirs packaging pyinstaller
+          pip install twine setuptools pytest pytest-xvfb pytest-cov appdirs packaging pyinstaller
           python -c "import tempfile, os; open(os.path.join(tempfile.gettempdir(), 'urh_releasing'), 'w').close()"
         shell: bash
         env:


### PR DESCRIPTION
`pytest-faulthandler`: This plugin is now part of pytest core since pytest 5.0, so users should not install this plugin together with that pytest version.
`six`: Six is a Python 2 and 3 compatibility library.