### PR TITLE
Drop python 3.8; Require python 3.9

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       
       - name: Install black
         run: pip install black==23.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,30 +15,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         architecture: [x64]
         include:
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.12'
             architecture: x86
-        exclude:
-          - os: windows-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.10'
           - os: windows-latest
             python-version: '3.12'
-          - os: macOS-13
-            python-version: '3.8'
-          - os: macOS-13
-            python-version: '3.9'
-          - os: macOS-13
-            python-version: '3.10'
+            architecture: x64
           - os: macOS-13
             python-version: '3.12'
+            architecture: x64
       fail-fast: false
 
     steps:
@@ -101,7 +90,7 @@ jobs:
         run: python src/urh/cythonext/build.py
 
       - name: Create sdist
-        if: ${{ matrix.python-version == '3.11' && startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.12' }}
         run: python setup.py sdist
 
       - run: python setup.py bdist_wheel
@@ -158,7 +147,7 @@ jobs:
           path: dist
 
       - name: Run pytest with coverage
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.11' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.12' }}
         run: |
           touch tests/show_gui
           cp tests/.coveragerc .
@@ -167,7 +156,7 @@ jobs:
           coverage html
 
       - name: Run pytest without coverage
-        if: ${{ !startsWith(matrix.os, 'ubuntu') || matrix.python-version != '3.11' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') || matrix.python-version != '3.12' }}
         run: pytest -s -v --junitxml=junit/test-results.xml tests
 
       - uses: ncipollo/release-action@v1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import os
 import sys
 import tempfile
 
-if sys.version_info < (3, 8):
-    print("You need at least Python 3.8 for this application!")
+if sys.version_info < (3, 9):
+    print("You need at least Python 3.9 for this application!")
     if sys.version_info[0] < 3:
         print("try running with python3 {}".format(" ".join(sys.argv)))
     sys.exit(1)
@@ -166,7 +166,7 @@ setup(
     download_url="https://github.com/jopohl/urh/tarball/v" + str(version.VERSION),
     install_requires=install_requires,
     setup_requires=["numpy<2.0.0"],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     packages=get_packages(),
     ext_modules=get_extensions(),
     cmdclass={"build_ext": build_ext},

--- a/src/urh/main.py
+++ b/src/urh/main.py
@@ -62,8 +62,8 @@ def fix_windows_stdout_stderr():
 def main():
     fix_windows_stdout_stderr()
 
-    if sys.version_info < (3, 8):
-        print("You need at least Python 3.8 for this application!")
+    if sys.version_info < (3, 9):
+        print("You need at least Python 3.9 for this application!")
         sys.exit(1)
 
     urh_exe = sys.executable if hasattr(sys, "frozen") else sys.argv[0]


### PR DESCRIPTION
python 3.8 is EOL
python 3.8 is not supported by numpy2

### Reference

Mentioned in https://github.com/jopohl/urh/issues/1149#issuecomment-2972767790