### PR TITLE
Fix deprecation warning xml.etree.ElementTree.Element

### DIFF
--- a/src/urh/signalprocessing/Message.py
+++ b/src/urh/signalprocessing/Message.py
@@ -630,7 +630,7 @@ class Message(object):
                     break
 
         message_type_tag = tag.find("message_type")
-        if message_type_tag:
+        if message_type_tag is not None:
             self.message_type = MessageType.from_xml(message_type_tag)
 
     @classmethod

--- a/src/urh/simulator/SimulatorConfiguration.py
+++ b/src/urh/simulator/SimulatorConfiguration.py
@@ -262,13 +262,13 @@ class SimulatorConfiguration(QObject):
         items = []
 
         modulators_tag = xml_tag.find("modulators")
-        if modulators_tag:
+        if modulators_tag is not None:
             self.project_manager.modulators = Modulator.modulators_from_xml_tag(
                 modulators_tag
             )
 
         participants_tag = xml_tag.find("participants")
-        if participants_tag:
+        if participants_tag is not None:
             for participant in Participant.read_participants_from_xml_tag(
                 participants_tag
             ):
@@ -277,19 +277,19 @@ class SimulatorConfiguration(QObject):
             self.participants_changed.emit()
 
         decodings_tag = xml_tag.find("decodings")
-        if decodings_tag:
+        if decodings_tag is not None:
             self.project_manager.decodings = Encoding.read_decoders_from_xml_tag(
                 decodings_tag
             )
 
         rx_config_tag = xml_tag.find("simulator_rx_conf")
-        if rx_config_tag:
+        if rx_config_tag is not None:
             ProjectManager.read_device_conf_dict(
                 rx_config_tag, self.project_manager.simulator_rx_conf
             )
 
         tx_config_tag = xml_tag.find("simulator_tx_conf")
-        if tx_config_tag:
+        if tx_config_tag is not None:
             ProjectManager.read_device_conf_dict(
                 tx_config_tag, self.project_manager.simulator_tx_conf
             )

--- a/src/urh/util/ProjectManager.py
+++ b/src/urh/util/ProjectManager.py
@@ -509,7 +509,7 @@ class ProjectManager(QObject):
                 messages_tag = sig_tag.find("messages")
 
                 try:
-                    if messages_tag:
+                    if messages_tag is not None:
                         for i, message_tag in enumerate(messages_tag.iter("message")):
                             messages[i].from_xml(message_tag, self.participants)
                 except IndexError:


### PR DESCRIPTION
DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.

Changed in version 3.12: Testing the truth value of an Element emits DeprecationWarning.

https://docs.python.org/3.12/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element