### PR TITLE
Revert numpy2 requirement

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=2.0,<3.0
+numpy<3.0
 pyqt5
 psutil
 cython<3.1

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ setup(
     license="GNU General Public License (GPL)",
     download_url="https://github.com/jopohl/urh/tarball/v" + str(version.VERSION),
     install_requires=install_requires,
-    setup_requires=["numpy>=2.0,<3.0"],
+    setup_requires=["numpy<3.0"],
     python_requires=">=3.9",
     packages=get_packages(),
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ def read_long_description():
         return ""
 
 
-install_requires = ["numpy>=2.0,<3.0", "psutil", "cython<3.1", "setuptools"]
+install_requires = ["numpy<3.0", "psutil", "cython<3.1", "setuptools"]
 if IS_RELEASE:
     install_requires.append("pyqt5")
 else:


### PR DESCRIPTION
Make URH compatible with Ubuntu 24.04 again. Thank you for bringing this up!

fix #1179