### PR TITLE
Fix compilation with Cython3.1.

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,5 +1,5 @@
 numpy<3.0
 pyqt5
 psutil
-cython<3.1
+cython
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ def read_long_description():
         return ""
 
 
-install_requires = ["numpy<3.0", "psutil", "cython<3.1", "setuptools"]
+install_requires = ["numpy<3.0", "psutil", "cython", "setuptools"]
 if IS_RELEASE:
     install_requires.append("pyqt5")
 else:

--- a/src/urh/dev/native/lib/chackrf.pxd
+++ b/src/urh/dev/native/lib/chackrf.pxd
@@ -54,7 +54,7 @@ cdef extern from "libhackrf/hackrf.h":
         uint32_t part_id[2]
         uint32_t serial_no[4]
 
-    ctypedef struct hackrf_device_list:
+    ctypedef struct c_hackrf_device_list "hackrf_device_list":
         char ** serial_numbers
         hackrf_usb_board_id * usb_board_ids
         int *usb_device_index
@@ -63,7 +63,7 @@ cdef extern from "libhackrf/hackrf.h":
         void ** usb_devices
         int usb_devicecount
 
-    ctypedef hackrf_device_list hackrf_device_list_t;
+    ctypedef c_hackrf_device_list hackrf_device_list_t;
 
     ctypedef int (*hackrf_sample_block_cb_fn)(hackrf_transfer* transfer)
 


### PR DESCRIPTION
Thanks to ahesford:

Failure to compile with Cython 3.1 is caused by a collision between struct hackrf_device_list and the function hackrf_device_list. In the C library that this wraps, the two names are distinct. Cython, however, folds struct hackrf_device_list into just hackrf_device_list. Fortunately, Cython allows the use of a name for its definitions that differs from the underlying C name, so the struct can just be called c_hackrf_device_list. This doesn't seem to be a critical change because the immediately following typedef just aliases this to hackrf_device_list_t everywhere it is needed.

Cf. http://docs.cython.org/en/stable/src/userguide/external_C_code.html#resolving-naming-conflicts-c-name-specifications