### PR TITLE
Fix error when saving compressed files

### DIFF
--- a/src/urh/signalprocessing/IQArray.py
+++ b/src/urh/signalprocessing/IQArray.py
@@ -262,7 +262,7 @@ class IQArray(object):
             tmp_name = tempfile.mkstemp()[1]
             self.tofile(tmp_name)
             tar_write.add(tmp_name)
-            os.remove(tmp_name)
+        os.remove(tmp_name)
 
     def export_to_wav(self, filename, num_channels, sample_rate):
         f = wave.open(filename, "w")

--- a/src/urh/util/FileOperator.py
+++ b/src/urh/util/FileOperator.py
@@ -6,9 +6,10 @@ import zipfile
 
 import numpy as np
 from PyQt6.QtCore import QDir
-from PyQt6.QtWidgets import QFileDialog, QMessageBox
+from PyQt6.QtWidgets import QFileDialog
 
 from urh.signalprocessing.IQArray import IQArray
+from urh.util.Errors import Errors
 
 archives = {}
 """:type: dict of [str, str]
@@ -173,7 +174,7 @@ def ask_signal_file_name_and_save(
         try:
             save_data(data, filename, sample_rate=sample_rate)
         except Exception as e:
-            QMessageBox.critical(parent, "Error saving signal", e.args[0])
+            Errors.exception(e)
             filename = None
     else:
         filename = None


### PR DESCRIPTION
Fix two bugs:

- On Windows, saving compressed files can cause issues as the temporary file is deleted before the archive is closed
- Displaying the error didn't use the `Errors.exception` helper method the last argument may have an invalid type